### PR TITLE
Centralize version management, bump to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modvis",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
                     opacity: 0.8
                   }}
                 >
-                  V0.7.6 (NICHT FÜR DEN PRODUKTIVEN EINSATZ!)
+                  V{__APP_VERSION__} (NICHT FÜR DEN PRODUKTIVEN EINSATZ!)
                 </Typography>
                 <Settings />
               </Box>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string };
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
Make package.json the single source of truth for the app version. Vite injects it as a build-time constant `__APP_VERSION__` via `define`, so the value is inlined as a literal at build and the AppBar reads it instead of hardcoding "V0.7.6".

- vite.config.ts: read package.json and define __APP_VERSION__
- src/vite-env.d.ts: declare the global constant for TS, plus the standard vite/client types reference
- src/App.tsx: render V{__APP_VERSION__} instead of the literal
- package.json: 0.1.0 → 0.8.0

Future version bumps now require editing package.json only.