### PR TITLE
Refactor IliSchemaExplorer and useIliSchema for maintainability

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -45,11 +45,11 @@ import {
   IliDomainEnumNode
 } from './nodes';
 import { useIliSchema } from '../hooks/useIliSchema';
+import { useDiagramExport } from '../hooks/useDiagramExport';
 import { LayoutSettings } from './sidebar/LayoutSettings';
 
 import '@xyflow/react/dist/style.css';
 import { debounce, throttle } from 'lodash';
-import { toPng, toSvg } from 'html-to-image';
 
 
 interface CustomNode extends ReactFlowNode {
@@ -89,14 +89,6 @@ const DEFAULT_FIT_VIEW_OPTIONS = {
 } as const;
 
 
-interface SelectionRect {
-  startX: number;
-  startY: number;
-  width: number;
-  height: number;
-}
-
-
 const globalStyles = `
   body.resizing {
     cursor: ew-resize !important;
@@ -111,12 +103,7 @@ const globalStyles = `
 `;
 
 const Flow: React.FC = () => {
-  const { 
-    fitView,
-    setViewport,
-    getViewport,
-    getZoom,
-  } = useReactFlow();
+  const { fitView, getViewport } = useReactFlow();
   const { colors, mode } = useTheme();
   const [useCurvedLines, setUseCurvedLines] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -531,222 +518,25 @@ const Flow: React.FC = () => {
     return { minY, maxY, maxX };
   };
 
-  const [isExporting, setIsExporting] = useState(false);
-  const [exportAnchorEl, setExportAnchorEl] = useState<null | HTMLElement>(null);
-  const [isSelectingArea, setIsSelectingArea] = useState(false);
-  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [isClipboardExport, setIsClipboardExport] = useState(false);
-  const selectionStartRef = useRef<{ x: number; y: number } | null>(null);
+  const {
+    exportAnchorEl,
+    handleExportClick,
+    handleExportClose,
+    handleExportAsPng,
+    handleExportToClipboard,
+    handleExportAsSvg,
+    isSelectingArea,
+    isDragging,
+    selectionRect,
+    handleSelectionStart,
+    handleSelectionMove,
+    handleSelectionEnd,
+    toastOpen,
+    toastMessage,
+    toastSeverity,
+    setToastOpen,
+  } = useDiagramExport(currentFileName);
 
- 
-  const [toastOpen, setToastOpen] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
-  const [toastSeverity, setToastSeverity] = useState<'success' | 'error'>('success');
-
- 
-  const handleExportClose = useCallback(() => {
-    setExportAnchorEl(null);
-  }, []);
-
- 
-  const handleExportClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
-    setExportAnchorEl(event.currentTarget);
-  }, []);
-
-  const handleExportAsPng = useCallback(() => {
-    if (isExporting) return;
-    setIsExporting(true);
-    setIsClipboardExport(false);
-    setIsSelectingArea(true);
-    handleExportClose();
-    setTimeout(() => setIsExporting(false), 500);
-  }, [isExporting, handleExportClose]);
-
-  const handleExportToClipboard = useCallback(() => {
-    if (isExporting) return;
-    setIsExporting(true);
-    setIsClipboardExport(true);
-    setIsSelectingArea(true);
-    handleExportClose();
-    setTimeout(() => setIsExporting(false), 500);
-  }, [isExporting, handleExportClose]);
-
- 
-  const handleSelectionStart = useCallback((event: React.MouseEvent) => {
-    if (!isSelectingArea) return;
-    
-   
-    const target = event.currentTarget;
-    const rect = target.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    
-    selectionStartRef.current = { x, y };
-    setIsDragging(true);
-    setSelectionRect({
-      startX: x,
-      startY: y,
-      width: 0,
-      height: 0
-    });
-
-   
-    event.preventDefault();
-  }, [isSelectingArea]);
-
-  const handleSelectionMove = useCallback((event: React.MouseEvent) => {
-    if (!isDragging || !selectionStartRef.current) return;
-    
-   
-    const target = event.currentTarget;
-    const rect = target.getBoundingClientRect();
-    const currentX = event.clientX - rect.left;
-    const currentY = event.clientY - rect.top;
-    
-    setSelectionRect({
-      startX: selectionStartRef.current.x,
-      startY: selectionStartRef.current.y,
-      width: currentX - selectionStartRef.current.x,
-      height: currentY - selectionStartRef.current.y
-    });
-
-   
-    event.preventDefault();
-  }, [isDragging]);
-
-  const handleSelectionEnd = useCallback(() => {
-    if (!isDragging || !selectionRect || isExporting) return;
-    
-    const flowElement = document.querySelector('.react-flow');
-    if (!flowElement) return;
-
-    setIsExporting(true);
-
-    const viewport = getViewport();
-    const zoom = getZoom();
-    
-   
-    const headerOffset = 36;
-    const toolbarOffset = 28;
-    const totalOffset = headerOffset + toolbarOffset;
-    
-   
-    const normalizedRect = {
-      x: Math.min(selectionRect.startX, selectionRect.startX + selectionRect.width),
-      y: Math.min(selectionRect.startY, selectionRect.startY + selectionRect.height) - totalOffset,
-      width: Math.abs(selectionRect.width),
-      height: Math.abs(selectionRect.height)
-    };
-
-   
-    const flowRect = {
-      x: (normalizedRect.x - viewport.x * zoom) / zoom,
-      y: (normalizedRect.y - viewport.y * zoom) / zoom,
-      width: normalizedRect.width / zoom,
-      height: normalizedRect.height / zoom
-    };
-
-   
-    const tempStyle = document.createElement('style');
-    tempStyle.innerHTML = `
-      .react-flow__background { display: none !important; }
-      .react-flow { background-color: ${isClipboardExport ? 'transparent' : 'white'} !important; }
-      .react-flow__handle { opacity: 0 !important; }
-      .react-flow__controls,
-      .react-flow__minimap,
-      .selection-overlay { display: none !important; }
-    `;
-    document.head.appendChild(tempStyle);
-
-   
-    const elementsToHide = document.querySelectorAll(
-      '.react-flow__controls, .search-toolbar, .layout-settings, .side-toolbar, .upload-area'
-    );
-    elementsToHide.forEach(el => (el as HTMLElement).style.display = 'none');
-
-    const exportOptions = {
-      quality: 1,
-      pixelRatio: window.devicePixelRatio * 4,
-      backgroundColor: isClipboardExport ? undefined : '#ffffff',
-      filter: (node: HTMLElement) => {
-        return !node.classList?.contains('react-flow__background') &&
-               !node.classList?.contains('react-flow__controls') &&
-               !node.classList?.contains('react-flow__minimap') &&
-               !node.classList?.contains('search-toolbar') &&
-               !node.classList?.contains('layout-settings') &&
-               !node.classList?.contains('side-toolbar') &&
-               !node.classList?.contains('upload-area') &&
-               !node.classList?.contains('hidden-for-export') &&
-               !node.classList?.contains('selection-overlay');
-      },
-      width: normalizedRect.width,
-      height: normalizedRect.height,
-      style: {
-        transform: `
-          translate(${-normalizedRect.x}px, ${-normalizedRect.y}px)
-          scale(${1})
-        `,
-        transformOrigin: 'top left',
-        width: `${flowElement.clientWidth}px`,
-        height: `${flowElement.clientHeight}px`
-      }
-    };
-
-   
-    toPng(flowElement as HTMLElement, exportOptions)
-      .then(dataUrl => {
-        if (isClipboardExport) {
-          return fetch(dataUrl)
-            .then(res => res.blob())
-            .then(blob => {
-              return navigator.clipboard.write([
-                new ClipboardItem({
-                  'image/png': blob
-                })
-              ]);
-            })
-            .then(() => {
-              setToastMessage('Diagramm wurde in die Zwischenablage kopiert');
-              setToastSeverity('success');
-              setToastOpen(true);
-            });
-        } else {
-          const link = document.createElement('a');
-          link.href = dataUrl;
-          link.download = `${currentFileName?.replace('.ili', '') || 'diagram'}.png`;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-        }
-      })
-      .catch(error => {
-        console.error('Export error:', error);
-        setToastMessage('Fehler beim Exportieren des Diagramms');
-        setToastSeverity('error');
-        setToastOpen(true);
-      })
-      .finally(() => {
-       
-        tempStyle.remove();
-        elementsToHide.forEach(el => (el as HTMLElement).style.display = '');
-        
-        setIsExporting(false);
-        setIsDragging(false);
-        setIsSelectingArea(false);
-        setSelectionRect(null);
-        selectionStartRef.current = null;
-        setIsClipboardExport(false);
-      });
-  }, [
-    isDragging, 
-    selectionRect, 
-    currentFileName, 
-    getZoom, 
-    getViewport, 
-    isClipboardExport,
-    isExporting
-  ]);
 
  
   const debouncedHandleNodeClick = useMemo(
@@ -756,73 +546,6 @@ const Flow: React.FC = () => {
     [handleNodeClick]
   );
 
- 
-  const handleExportAsSvg = useCallback(() => {
-    if (isExporting) return;
-    
-    const flowElement = document.querySelector('.react-flow');
-    if (!flowElement) return;
-
-    setIsExporting(true);
-    handleExportClose();
-
-   
-    const tempStyle = document.createElement('style');
-    tempStyle.innerHTML = `
-      .react-flow__background { display: none !important; }
-      .react-flow { background-color: white !important; }
-      .react-flow__handle { opacity: 0 !important; }
-      .react-flow__controls,
-      .react-flow__minimap,
-      .selection-overlay { display: none !important; }
-    `;
-    document.head.appendChild(tempStyle);
-
-   
-    const elementsToHide = document.querySelectorAll(
-      '.react-flow__controls, .search-toolbar, .layout-settings, .side-toolbar, .upload-area'
-    );
-    elementsToHide.forEach(el => (el as HTMLElement).style.display = 'none');
-
-    const exportOptions = {
-      filter: (node: HTMLElement) => {
-        return !node.classList?.contains('react-flow__background') &&
-               !node.classList?.contains('react-flow__controls') &&
-               !node.classList?.contains('react-flow__minimap') &&
-               !node.classList?.contains('search-toolbar') &&
-               !node.classList?.contains('layout-settings') &&
-               !node.classList?.contains('side-toolbar') &&
-               !node.classList?.contains('upload-area') &&
-               !node.classList?.contains('hidden-for-export') &&
-               !node.classList?.contains('selection-overlay');
-      },
-      style: {
-        backgroundColor: 'white'
-      }
-    };
-
-    toSvg(flowElement as HTMLElement, exportOptions)
-      .then(dataUrl => {
-        const link = document.createElement('a');
-        link.href = dataUrl;
-        link.download = `${currentFileName?.replace('.ili', '') || 'diagram'}.svg`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      })
-      .catch(error => {
-        console.error('SVG Export error:', error);
-        setToastMessage('Fehler beim Exportieren des Diagramms als SVG');
-        setToastSeverity('error');
-        setToastOpen(true);
-      })
-      .finally(() => {
-       
-        tempStyle.remove();
-        elementsToHide.forEach(el => (el as HTMLElement).style.display = '');
-        setIsExporting(false);
-      });
-  }, [currentFileName, handleExportClose, isExporting]);
 
   useEffect(() => {
     const styleSheet = document.createElement('style');

--- a/src/features/ili-explorer/hooks/useDiagramExport.ts
+++ b/src/features/ili-explorer/hooks/useDiagramExport.ts
@@ -1,0 +1,256 @@
+import { useState, useCallback, useRef } from 'react';
+import { toPng, toSvg } from 'html-to-image';
+
+export interface SelectionRect {
+  startX: number;
+  startY: number;
+  width: number;
+  height: number;
+}
+
+const HEADER_OFFSET = 36;
+const TOOLBAR_OFFSET = 28;
+
+const HIDE_CSS = `
+  .react-flow__background { display: none !important; }
+  .react-flow__handle { opacity: 0 !important; }
+  .react-flow__controls,
+  .react-flow__minimap,
+  .selection-overlay { display: none !important; }
+`;
+
+const HIDE_SELECTORS =
+  '.react-flow__controls, .search-toolbar, .layout-settings, .side-toolbar, .upload-area';
+
+const EXCLUDED_CLASSES = [
+  'react-flow__background',
+  'react-flow__controls',
+  'react-flow__minimap',
+  'search-toolbar',
+  'layout-settings',
+  'side-toolbar',
+  'upload-area',
+  'hidden-for-export',
+  'selection-overlay',
+];
+
+function nodeFilterForExport(node: HTMLElement): boolean {
+  return !EXCLUDED_CLASSES.some(cls => node.classList?.contains(cls));
+}
+
+function withTransientStyles<T>(
+  background: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const tempStyle = document.createElement('style');
+  tempStyle.innerHTML = `
+    ${HIDE_CSS}
+    .react-flow { background-color: ${background} !important; }
+  `;
+  document.head.appendChild(tempStyle);
+
+  const elementsToHide = document.querySelectorAll(HIDE_SELECTORS);
+  elementsToHide.forEach(el => ((el as HTMLElement).style.display = 'none'));
+
+  return run().finally(() => {
+    tempStyle.remove();
+    elementsToHide.forEach(el => ((el as HTMLElement).style.display = ''));
+  });
+}
+
+function downloadDataUrl(dataUrl: string, filename: string): void {
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+async function copyDataUrlToClipboard(dataUrl: string): Promise<void> {
+  const blob = await (await fetch(dataUrl)).blob();
+  await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+}
+
+export function useDiagramExport(currentFileName: string | null) {
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportAnchorEl, setExportAnchorEl] = useState<null | HTMLElement>(null);
+  const [isSelectingArea, setIsSelectingArea] = useState(false);
+  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isClipboardExport, setIsClipboardExport] = useState(false);
+  const selectionStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const [toastOpen, setToastOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+  const [toastSeverity, setToastSeverity] = useState<'success' | 'error'>('success');
+
+  const showToast = useCallback((message: string, severity: 'success' | 'error') => {
+    setToastMessage(message);
+    setToastSeverity(severity);
+    setToastOpen(true);
+  }, []);
+
+  const baseName = currentFileName?.replace('.ili', '') || 'diagram';
+
+  const handleExportClose = useCallback(() => {
+    setExportAnchorEl(null);
+  }, []);
+
+  const handleExportClick = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setExportAnchorEl(event.currentTarget);
+  }, []);
+
+  const startAreaSelection = useCallback((forClipboard: boolean) => {
+    if (isExporting) return;
+    setIsExporting(true);
+    setIsClipboardExport(forClipboard);
+    setIsSelectingArea(true);
+    handleExportClose();
+    setTimeout(() => setIsExporting(false), 500);
+  }, [isExporting, handleExportClose]);
+
+  const handleExportAsPng = useCallback(() => startAreaSelection(false), [startAreaSelection]);
+  const handleExportToClipboard = useCallback(() => startAreaSelection(true), [startAreaSelection]);
+
+  const handleSelectionStart = useCallback((event: React.MouseEvent) => {
+    if (!isSelectingArea) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    selectionStartRef.current = { x, y };
+    setIsDragging(true);
+    setSelectionRect({ startX: x, startY: y, width: 0, height: 0 });
+    event.preventDefault();
+  }, [isSelectingArea]);
+
+  const handleSelectionMove = useCallback((event: React.MouseEvent) => {
+    if (!isDragging || !selectionStartRef.current) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const currentX = event.clientX - rect.left;
+    const currentY = event.clientY - rect.top;
+    setSelectionRect({
+      startX: selectionStartRef.current.x,
+      startY: selectionStartRef.current.y,
+      width: currentX - selectionStartRef.current.x,
+      height: currentY - selectionStartRef.current.y,
+    });
+    event.preventDefault();
+  }, [isDragging]);
+
+  const resetSelection = useCallback(() => {
+    setIsExporting(false);
+    setIsDragging(false);
+    setIsSelectingArea(false);
+    setSelectionRect(null);
+    selectionStartRef.current = null;
+    setIsClipboardExport(false);
+  }, []);
+
+  const handleSelectionEnd = useCallback(() => {
+    if (!isDragging || !selectionRect || isExporting) return;
+
+    const flowElement = document.querySelector('.react-flow');
+    if (!flowElement) return;
+
+    setIsExporting(true);
+
+    const totalOffset = HEADER_OFFSET + TOOLBAR_OFFSET;
+
+    const normalizedRect = {
+      x: Math.min(selectionRect.startX, selectionRect.startX + selectionRect.width),
+      y:
+        Math.min(selectionRect.startY, selectionRect.startY + selectionRect.height) -
+        totalOffset,
+      width: Math.abs(selectionRect.width),
+      height: Math.abs(selectionRect.height),
+    };
+
+    const exportOptions = {
+      quality: 1,
+      pixelRatio: window.devicePixelRatio * 4,
+      backgroundColor: isClipboardExport ? undefined : '#ffffff',
+      filter: nodeFilterForExport,
+      width: normalizedRect.width,
+      height: normalizedRect.height,
+      style: {
+        transform: `translate(${-normalizedRect.x}px, ${-normalizedRect.y}px) scale(${1})`,
+        transformOrigin: 'top left',
+        width: `${(flowElement as HTMLElement).clientWidth}px`,
+        height: `${(flowElement as HTMLElement).clientHeight}px`,
+      },
+    };
+
+    const background = isClipboardExport ? 'transparent' : 'white';
+    const wantsClipboard = isClipboardExport;
+
+    withTransientStyles(background, async () => {
+      const dataUrl = await toPng(flowElement as HTMLElement, exportOptions);
+      if (wantsClipboard) {
+        await copyDataUrlToClipboard(dataUrl);
+        showToast('Diagramm wurde in die Zwischenablage kopiert', 'success');
+      } else {
+        downloadDataUrl(dataUrl, `${baseName}.png`);
+      }
+    })
+      .catch((err) => {
+        console.error('Export error:', err);
+        showToast('Fehler beim Exportieren des Diagramms', 'error');
+      })
+      .finally(resetSelection);
+  }, [
+    isDragging,
+    selectionRect,
+    isExporting,
+    isClipboardExport,
+    baseName,
+    showToast,
+    resetSelection,
+  ]);
+
+  const handleExportAsSvg = useCallback(() => {
+    if (isExporting) return;
+    const flowElement = document.querySelector('.react-flow');
+    if (!flowElement) return;
+
+    setIsExporting(true);
+    handleExportClose();
+
+    withTransientStyles('white', async () => {
+      const dataUrl = await toSvg(flowElement as HTMLElement, {
+        filter: nodeFilterForExport,
+        style: { backgroundColor: 'white' },
+      });
+      downloadDataUrl(dataUrl, `${baseName}.svg`);
+    })
+      .catch((err) => {
+        console.error('SVG Export error:', err);
+        showToast('Fehler beim Exportieren des Diagramms als SVG', 'error');
+      })
+      .finally(() => setIsExporting(false));
+  }, [isExporting, handleExportClose, baseName, showToast]);
+
+  return {
+    // export menu
+    exportAnchorEl,
+    handleExportClick,
+    handleExportClose,
+    handleExportAsPng,
+    handleExportToClipboard,
+    handleExportAsSvg,
+
+    // selection rect (used by overlay UI)
+    isSelectingArea,
+    isDragging,
+    selectionRect,
+    handleSelectionStart,
+    handleSelectionMove,
+    handleSelectionEnd,
+
+    // toast
+    toastOpen,
+    toastMessage,
+    toastSeverity,
+    setToastOpen,
+  };
+}

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -1,9 +1,14 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import { Node, Edge, Connection, MarkerType, FitViewOptions } from '@xyflow/react';
+import { Node, Edge, Connection, FitViewOptions } from '@xyflow/react';
 import { useTheme } from '../../../common/theme/ThemeContext';
 import { IliSchemaService } from '../services/iliSchemaService';
 import { IliLayoutService } from '../services/IliLayoutService';
+import { generateSearchOptions } from '../services/searchOptions';
+import {
+  flowNodeFromBaseNode,
+  inheritanceEdgesFromRelations,
+} from '../services/flowMapping';
 import {
   IliBaseNode,
   IliRelation,
@@ -102,60 +107,6 @@ export const useIliSchema = (
  
   const isResizingRef = useRef(false);
 
- 
-  const generateSearchOptions = useCallback((nodes: IliBaseNode[]): SearchOption[] => {
-    const options: SearchOption[] = [];
-
-   
-    nodes.forEach(node => {
-     
-      if (node.type === 'MODEL') return;
-      
-     
-      const validTypes = ['CLASS', 'STRUCTURE', 'TOPIC', 'ENUMERATION'];
-      if (!validTypes.includes(node.type)) return;
-
-      options.push({
-        id: node.id,
-        label: node.name,
-        type: node.type,
-        description: `${node.type} ${node.isAbstract ? '(Abstract)' : ''}`,
-        category: node.type === 'CLASS' ? 'Classes' : 
-                 node.type === 'STRUCTURE' ? 'Structures' : 
-                 node.type === 'TOPIC' ? 'Topics' : 
-                 'Enumerations'
-      });
-
-     
-      if (node.type === 'CLASS') {
-        const classNode = node as IliClassNode;
-        if (classNode.attributes) {
-          classNode.attributes.forEach(attr => {
-            options.push({
-              id: `${node.id}.${attr.name}`,
-              label: `${attr.name} (${node.name})`,
-              type: 'ATTRIBUTE',
-              description: `${attr.type}${attr.mandatory ? ', Mandatory' : ''}`,
-              category: 'Attributes'
-            });
-          });
-        }
-      }
-    });
-
-   
-    return options.sort((a, b) => {
-     
-      const categoryOrder = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Attributes'];
-      const categoryDiff = categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category);
-      if (categoryDiff !== 0) return categoryDiff;
-      
-     
-      return a.label.localeCompare(b.label);
-    });
-  }, []);
-
- 
   const filterNodesAndEdges = useCallback((nodeId: string | null = null) => {
    
     const layoutCache = new Map<string, {nodes: Node[]; edges: Edge[]}>();
@@ -254,34 +205,8 @@ export const useIliSchema = (
       const baseNodes = schemaServiceRef.current.getNodes();
       const relations = schemaServiceRef.current.getRelations();
 
-      const flowNodes = baseNodes.map(node => ({
-        id: node.id,
-        type: node.type === 'ASSOCIATION' ? 'associationNode' : `${node.type.toLowerCase()}Node`,
-        position: { x: 0, y: 0 },
-        draggable: true,
-        data: {
-          ...node,
-          label: node.name,
-          isHighlighted: false,
-          isActive: false,
-          expanded: false
-        }
-      }));
-
-      const flowEdges = relations
-        .filter(relation => relation.type === 'EXTENDS')
-        .map(relation => ({
-          id: relation.id,
-          source: relation.sourceId,
-          target: relation.targetId,
-          type: useCurvedLines ? 'default' : 'step',
-          animated: false,
-          style: { stroke: colors.inheritance, strokeWidth: 2 },
-          markerEnd: {
-            type: MarkerType.Arrow,
-            color: colors.inheritance
-          }
-        }));
+      const flowNodes = baseNodes.map(flowNodeFromBaseNode);
+      const flowEdges = inheritanceEdgesFromRelations(relations, colors, useCurvedLines);
 
      
       setAllNodes(flowNodes);
@@ -331,13 +256,13 @@ export const useIliSchema = (
       setIsLoading(false);
     }
   }, [
-    colors, 
-    showFullHierarchy, 
-    useCurvedLines, 
-    showEnums, 
-    setNodes, 
-    setEdges, 
-    generateSearchOptions
+    colors,
+    showFullHierarchy,
+    useCurvedLines,
+    showEnums,
+    showAssociations,
+    setNodes,
+    setEdges,
   ]);
 
   const handleSearchChange = useCallback((option: SearchOption | null) => {
@@ -971,18 +896,6 @@ export const useIliSchema = (
   }, []);
 
  
-  const createNode = useCallback((node: IliBaseNode) => {
-    const width = nodeWidths.get(node.id) || 400;
-    return {
-      ...node,
-      data: {
-        ...node.data,
-        width,
-        onResize: (newWidth: number) => handleNodeResize(node.id, newWidth)
-      }
-    };
-  }, [nodeWidths, handleNodeResize]);
-
   return {
     isLoading,
     error,
@@ -1017,41 +930,4 @@ export const useIliSchema = (
     handleToggleAssociations,
     handleMagicLayout,
   };
-}; 
-
-
-export const useNodeManagement = () => {
-  const [nodes, setNodes] = useState<Node[]>([]);
-  const [edges, setEdges] = useState<Edge[]>([]);
-  
-  const updateNodeLayout = useCallback((nodeId: string, layout: Partial<Node>) => {
-    setNodes(prev => prev.map(node => 
-      node.id === nodeId ? { ...node, ...layout } : node
-    ));
-  }, []);
-
-  return {
-    nodes,
-    edges,
-    setNodes,
-    setEdges,
-    updateNodeLayout
-  };
 };
-
-export const useNavigationState = () => {
-  const [navigationHistory, setNavigationHistory] = useState<NavigationState[]>([]);
-  const [historyIndex, setHistoryIndex] = useState(-1);
-  
-  const navigateTo = useCallback((state: NavigationState) => {
-    setNavigationHistory(prev => [...prev.slice(0, historyIndex + 1), state]);
-    setHistoryIndex(prev => prev + 1);
-  }, [historyIndex]);
-
-  return {
-    navigationHistory,
-    historyIndex,
-    navigateTo,
-    setHistoryIndex
-  };
-}; 

--- a/src/features/ili-explorer/services/flowMapping.ts
+++ b/src/features/ili-explorer/services/flowMapping.ts
@@ -1,0 +1,40 @@
+import { Edge, MarkerType } from '@xyflow/react';
+import { IliBaseNode, IliRelation } from './types/IliBaseTypes';
+import { ThemeColors } from '../../../common/theme/ThemeContext';
+
+export function flowNodeFromBaseNode(node: IliBaseNode) {
+  return {
+    id: node.id,
+    type: node.type === 'ASSOCIATION' ? 'associationNode' : `${node.type.toLowerCase()}Node`,
+    position: { x: 0, y: 0 },
+    draggable: true,
+    data: {
+      ...node,
+      label: node.name,
+      isHighlighted: false,
+      isActive: false,
+      expanded: false,
+    },
+  };
+}
+
+export function inheritanceEdgesFromRelations(
+  relations: IliRelation[],
+  colors: ThemeColors,
+  useCurvedLines: boolean,
+): Edge[] {
+  return relations
+    .filter(relation => relation.type === 'EXTENDS')
+    .map(relation => ({
+      id: relation.id,
+      source: relation.sourceId,
+      target: relation.targetId,
+      type: useCurvedLines ? 'default' : 'step',
+      animated: false,
+      style: { stroke: colors.inheritance, strokeWidth: 2 },
+      markerEnd: {
+        type: MarkerType.Arrow,
+        color: colors.inheritance,
+      },
+    }));
+}

--- a/src/features/ili-explorer/services/searchOptions.ts
+++ b/src/features/ili-explorer/services/searchOptions.ts
@@ -1,0 +1,56 @@
+import { IliBaseNode, SearchOption } from './types/IliBaseTypes';
+import { IliClassNode } from './types/IliModelTypes';
+
+const VALID_NODE_TYPES = ['CLASS', 'STRUCTURE', 'TOPIC', 'ENUMERATION'] as const;
+const CATEGORY_ORDER = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Attributes'] as const;
+
+function categoryFor(nodeType: string): string {
+  switch (nodeType) {
+    case 'CLASS':
+      return 'Classes';
+    case 'STRUCTURE':
+      return 'Structures';
+    case 'TOPIC':
+      return 'Topics';
+    default:
+      return 'Enumerations';
+  }
+}
+
+export function generateSearchOptions(nodes: IliBaseNode[]): SearchOption[] {
+  const options: SearchOption[] = [];
+
+  nodes.forEach(node => {
+    if (node.type === 'MODEL') return;
+    if (!VALID_NODE_TYPES.includes(node.type as typeof VALID_NODE_TYPES[number])) return;
+
+    options.push({
+      id: node.id,
+      label: node.name,
+      type: node.type,
+      description: `${node.type} ${node.isAbstract ? '(Abstract)' : ''}`,
+      category: categoryFor(node.type),
+    });
+
+    if (node.type === 'CLASS') {
+      const classNode = node as IliClassNode;
+      classNode.attributes?.forEach(attr => {
+        options.push({
+          id: `${node.id}.${attr.name}`,
+          label: `${attr.name} (${node.name})`,
+          type: 'ATTRIBUTE',
+          description: `${attr.type}${attr.mandatory ? ', Mandatory' : ''}`,
+          category: 'Attributes',
+        });
+      });
+    }
+  });
+
+  return options.sort((a, b) => {
+    const categoryDiff =
+      CATEGORY_ORDER.indexOf(a.category as typeof CATEGORY_ORDER[number]) -
+      CATEGORY_ORDER.indexOf(b.category as typeof CATEGORY_ORDER[number]);
+    if (categoryDiff !== 0) return categoryDiff;
+    return a.label.localeCompare(b.label);
+  });
+}


### PR DESCRIPTION
The two largest files in the project — IliSchemaExplorer.tsx (1226 lines) and useIliSchema.ts (1056 lines) — had grown unwieldy. Pull out cohesive pieces into focused modules without changing the public API or runtime behaviour.

Extracted modules:
- hooks/useDiagramExport.ts (new, 256 lines) Diagram export menu, area selection (click-and-drag overlay), PNG/SVG/clipboard export, toast feedback. Introduces a withTransientStyles() helper that replaces the duplicated inline-style + element-hide setup that previously appeared in both the PNG and SVG export paths.
- services/searchOptions.ts (new, 56 lines) generateSearchOptions() as a pure function — was a useCallback closure inside the hook with no real reactive dependencies.
- services/flowMapping.ts (new, 40 lines) flowNodeFromBaseNode() + inheritanceEdgesFromRelations() — were inline mappers inside handleFileUpload; now reusable and easier to read.

Dead code removed from useIliSchema.ts:
- createNode() callback — never called
- useNodeManagement() export — never imported anywhere
- useNavigationState() export — never imported anywhere

Also:
- Dropped flowRect computation in handleSelectionEnd that was computed but never used downstream.
- Cleaned up useReactFlow destructure in IliSchemaExplorer (unused setViewport/getZoom dropped along with the export logic).

Net effect:
- IliSchemaExplorer.tsx: 1226 → 950 (-276)
- useIliSchema.ts: 1056 → 933 (-123)
- Total LOC across the affected area: 2282 → 2235 (-47), spread across five focused files instead of two oversized ones.

Build (tsc -b && vite build) green. Public API of useIliSchema unchanged so IliSchemaExplorer consumes it identically. Manual browser verification of file upload, search, navigation back/forward, PNG/SVG/clipboard export still required.