### PR TITLE
feat: experimental flag, drag-drop upload, beta banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { Box, AppBar, Toolbar, Typography, Tabs, Tab } from '@mui/material';
-import { Schema } from '@mui/icons-material';
+import { Box, AppBar, Toolbar, Typography, Tabs, Tab, Chip } from '@mui/material';
+import { Schema, Science } from '@mui/icons-material';
 import { useTheme } from './common/theme/ThemeContext';
+import { useSettings } from './common/settings/SettingsContext';
 import { Settings } from './common/components/Settings';
 
 import { ExpExplorer } from './features/exp-explorer/expExplorer';
@@ -11,7 +12,14 @@ import { IliSchemaExplorer } from './features/ili-explorer/components/IliSchemaE
 
 function App() {
   const { mode, colors } = useTheme();
+  const { experimentalFeatures } = useSettings();
   const [currentTab, setCurrentTab] = useState(0);
+
+  useEffect(() => {
+    if (!experimentalFeatures && currentTab === 1) {
+      setCurrentTab(0);
+    }
+  }, [experimentalFeatures, currentTab]);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setCurrentTab(newValue);
@@ -165,6 +173,18 @@ function App() {
                 }}
               >
                 MODVIS
+                {currentTab === 0 && (
+                  <Box component="span" sx={{ opacity: 0.6, fontWeight: 500, mx: 1 }}>·</Box>
+                )}
+                {currentTab === 0 && (
+                  <Box component="span" sx={{ fontWeight: 500 }}>ILI Explorer</Box>
+                )}
+                {currentTab === 1 && experimentalFeatures && (
+                  <Box component="span" sx={{ opacity: 0.6, fontWeight: 500, mx: 1 }}>·</Box>
+                )}
+                {currentTab === 1 && experimentalFeatures && (
+                  <Box component="span" sx={{ fontWeight: 500 }}>EXP Explorer</Box>
+                )}
               </Typography>
               <Box sx={{ 
                 display: 'flex', 
@@ -180,7 +200,7 @@ function App() {
                     opacity: 0.8
                   }}
                 >
-                  V{__APP_VERSION__} (NICHT FÜR DEN PRODUKTIVEN EINSATZ!)
+                  V{__APP_VERSION__} (BETA)
                 </Typography>
                 <Settings />
               </Box>
@@ -246,17 +266,33 @@ function App() {
                   label="ILI Explorer"
                   iconPosition="start"
                 />
-                <Tab
-                  icon={<Schema fontSize="small" />}
-                  label="EXP Explorer"
-                  iconPosition="start"
-                />
+                {experimentalFeatures && (
+                  <Tab
+                    icon={<Science fontSize="small" />}
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        EXP Explorer
+                        <Chip
+                          label="experimentell"
+                          size="small"
+                          sx={{
+                            height: 16,
+                            fontSize: '0.625rem',
+                            color: '#fff',
+                            bgcolor: 'rgba(255,255,255,0.2)',
+                          }}
+                        />
+                      </Box>
+                    }
+                    iconPosition="start"
+                  />
+                )}
               </Tabs>
             </Box>
           </AppBar>
 
         {currentTab === 0 && <IliSchemaExplorer />}
-        {currentTab === 1 && <ExpExplorer />}
+        {currentTab === 1 && experimentalFeatures && <ExpExplorer />}
       </Box>
     </MuiThemeProvider>
   );

--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -13,9 +13,11 @@ import {
 } from '@mui/material';
 import { Settings as SettingsIcon } from '@mui/icons-material';
 import { useTheme } from '../theme/ThemeContext';
+import { useSettings } from '../settings/SettingsContext';
 
 const Settings: React.FC = () => {
   const { mode, setMode, colorScheme, setColorScheme } = useTheme();
+  const { experimentalFeatures, setExperimentalFeatures } = useSettings();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -98,9 +100,9 @@ const Settings: React.FC = () => {
                 </Box>
               }
             />
-            <FormControlLabel 
-              value="purple" 
-              control={<Radio size="small" />} 
+            <FormControlLabel
+              value="purple"
+              control={<Radio size="small" />}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <Box sx={{ width: 16, height: 16, bgcolor: '#9d18e9', borderRadius: 1 }} />
@@ -110,9 +112,23 @@ const Settings: React.FC = () => {
             />
           </RadioGroup>
         </MenuItem>
+        <Divider />
+        <MenuItem>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={experimentalFeatures}
+                onChange={(e) => setExperimentalFeatures(e.target.checked)}
+                color="primary"
+              />
+            }
+            label="Experimentelle Features"
+          />
+        </MenuItem>
       </Menu>
     </>
   );
-} 
+}
+
 
 export { Settings };

--- a/src/common/settings/SettingsContext.tsx
+++ b/src/common/settings/SettingsContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+interface SettingsContextType {
+  experimentalFeatures: boolean;
+  setExperimentalFeatures: (enabled: boolean) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'experimentalFeatures';
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [experimentalFeatures, setExperimentalFeatures] = useState<boolean>(() => {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(experimentalFeatures));
+  }, [experimentalFeatures]);
+
+  return (
+    <SettingsContext.Provider value={{ experimentalFeatures, setExperimentalFeatures }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): SettingsContextType {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return ctx;
+}

--- a/src/features/exp-explorer/components/expExplorerLayout.tsx
+++ b/src/features/exp-explorer/components/expExplorerLayout.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useCallback } from 'react';
-import { Box, Paper, Tooltip, Typography, IconButton } from '@mui/material';
+import React, { useState, useMemo, useCallback, useRef } from 'react';
+import { Box, Paper, Tooltip, Typography, IconButton, Snackbar, Alert } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { ExpSchemaFlow } from './expGraph';
 import { ExpSchemaControls } from './expSearchBar';
 import { useTheme } from '../../../common/theme/ThemeContext';
@@ -12,6 +13,19 @@ export const ExpSchemaExplorer: React.FC = () => {
   const [searchValue, setSearchValue] = useState<SearchOption | null>(null);
   const [expressData, setExpressData] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+  const [isFileDragging, setIsFileDragging] = useState(false);
+  const [errorOpen, setErrorOpen] = useState(false);
+  const dragCounterRef = useRef(0);
+
+  const loadFile = useCallback(async (file: File) => {
+    if (!file.name.toLowerCase().endsWith('.exp')) {
+      setErrorOpen(true);
+      return;
+    }
+    const content = await file.text();
+    setExpressData(content);
+    setFileName(file.name);
+  }, []);
 
   const { searchOptions } = useMemo(() => {
     if (!expressData) return { searchOptions: [] };
@@ -44,16 +58,46 @@ export const ExpSchemaExplorer: React.FC = () => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.exp';
-    input.onchange = async (e) => {
+    input.onchange = (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
-      if (file && file.name.endsWith('.exp')) {
-        const content = await file.text();
-        setExpressData(content);
-        setFileName(file.name);
-      }
+      if (file) loadFile(file);
     };
     input.click();
   };
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current += 1;
+    if (dragCounterRef.current === 1) setIsFileDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current -= 1;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setIsFileDragging(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsFileDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) loadFile(file);
+  }, [loadFile]);
 
   const handleClearFile = () => {
     setExpressData(null);
@@ -68,10 +112,16 @@ export const ExpSchemaExplorer: React.FC = () => {
   }, []);
 
   return (
-    <Box sx={{
-      height: 'calc(100vh - 64px)',
-      position: 'relative'
-    }}>
+    <Box
+      sx={{
+        height: 'calc(100vh - 64px)',
+        position: 'relative'
+      }}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       <Box sx={{
         position: 'absolute',
         top: 0,
@@ -86,6 +136,53 @@ export const ExpSchemaExplorer: React.FC = () => {
           onNodeNavigation={handleNodeNavigation}
         />
       </Box>
+
+      {isFileDragging && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1500,
+            bgcolor: alpha(colors.primary, 0.1),
+            border: `3px dashed ${colors.primary}`,
+            borderRadius: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          <Paper
+            elevation={6}
+            sx={{
+              px: 4,
+              py: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              bgcolor: 'background.paper',
+            }}
+          >
+            <Upload sx={{ fontSize: 48, color: colors.primary }} />
+            <Typography variant="h6">EXPRESS-Schema hier ablegen</Typography>
+            <Typography variant="caption" sx={{ color: colors.secondaryText }}>
+              Nur .exp-Dateien werden akzeptiert
+            </Typography>
+          </Paper>
+        </Box>
+      )}
+
+      <Snackbar
+        open={errorOpen}
+        autoHideDuration={3000}
+        onClose={() => setErrorOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={() => setErrorOpen(false)} severity="error" sx={{ width: '100%' }}>
+          Nur .exp-Dateien werden unterstützt
+        </Alert>
+      </Snackbar>
 
       <Box sx={{
         position: 'absolute',

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -419,7 +419,6 @@ const Flow: React.FC = () => {
     handleExportToClipboard,
     handleExportAsSvg,
     isSelectingArea,
-    isDragging,
     selectionRect,
     handleSelectionStart,
     handleSelectionMove,
@@ -428,7 +427,59 @@ const Flow: React.FC = () => {
     toastMessage,
     toastSeverity,
     setToastOpen,
+    showToast,
   } = useDiagramExport(currentFileName);
+
+  const [isFileDragging, setIsFileDragging] = useState(false);
+  const dragCounterRef = useRef(0);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (isSelectingArea) return;
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current += 1;
+    if (dragCounterRef.current === 1) {
+      setIsFileDragging(true);
+    }
+  }, [isSelectingArea]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (isSelectingArea) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current -= 1;
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0;
+      setIsFileDragging(false);
+    }
+  }, [isSelectingArea]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (isSelectingArea) return;
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+  }, [isSelectingArea]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    if (isSelectingArea) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsFileDragging(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+
+    if (!file.name.toLowerCase().endsWith('.ili')) {
+      showToast('Nur .ili-Dateien werden unterstützt', 'error');
+      return;
+    }
+
+    handleFileUpload(file);
+  }, [isSelectingArea, handleFileUpload, showToast]);
 
 
  
@@ -451,7 +502,49 @@ const Flow: React.FC = () => {
   }, []);
 
   return (
-    <>
+    <Box
+      sx={{ position: 'absolute', inset: 0 }}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {isFileDragging && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 1500,
+            bgcolor: alpha(colors.primary, 0.1),
+            border: `3px dashed ${colors.primary}`,
+            borderRadius: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          <Paper
+            elevation={6}
+            sx={{
+              px: 4,
+              py: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              bgcolor: 'background.paper',
+            }}
+          >
+            <Upload sx={{ fontSize: 48, color: colors.primary }} />
+            <Typography variant="h6">INTERLIS-Modell hier ablegen</Typography>
+            <Typography variant="caption" sx={{ color: colors.secondaryText }}>
+              Nur .ili-Dateien werden akzeptiert
+            </Typography>
+          </Paper>
+        </Box>
+      )}
+
       {isLoading && (
         <Box
           sx={{
@@ -813,7 +906,7 @@ const Flow: React.FC = () => {
           )}
         </div>
       )}
-    </>
+    </Box>
   );
 };
 

--- a/src/features/ili-explorer/hooks/useDiagramExport.ts
+++ b/src/features/ili-explorer/hooks/useDiagramExport.ts
@@ -252,5 +252,6 @@ export function useDiagramExport(currentFileName: string | null) {
     toastMessage,
     toastSeverity,
     setToastOpen,
+    showToast,
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,17 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ThemeProvider } from './common/theme/ThemeContext'
+import { SettingsProvider } from './common/settings/SettingsContext'
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Root element not found');
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <SettingsProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </SettingsProvider>
   </React.StrictMode>,
-) 
+)


### PR DESCRIPTION
- Add SettingsContext (localStorage-backed) with an experimentalFeatures toggle, default off, exposed via a Switch in the Settings menu.
- Hide the EXP Explorer tab behind the experimental flag. When the flag is turned off while the EXP tab is active, switch back to the ILI tab automatically. The tab label carries an "experimentell" chip and a Science icon to signal its status.
- Add drag-and-drop file loading to both explorers. A dragCounter ref prevents flicker on child-element enter/leave events; a dashed-border overlay shows the drop target. Only .ili / .exp files are accepted; the wrong extension surfaces a Snackbar error. Drop is disabled while the export area-selection is running.
- Show the active explorer in the AppBar title: "MODVIS · ILI Explorer" / "MODVIS · EXP Explorer", with the separator and sub-title visually subordinate to the brand.