### PR TITLE
test+fix: vitest smoke tests and uncovered parser bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "modvis",
       "version": "0.8.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -28,7 +29,8 @@
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.6.3",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1482,6 +1484,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -1517,6 +1526,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-color": {
@@ -1555,6 +1575,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1631,6 +1658,126 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@xyflow/react": {
       "version": "12.10.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
@@ -1661,6 +1808,16 @@
         "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -1744,6 +1901,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/classcat": {
       "version": "5.0.5",
@@ -1914,6 +2081,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "dev": true,
@@ -1970,6 +2144,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2133,6 +2327,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -2165,6 +2369,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -2202,6 +2417,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2397,6 +2619,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
@@ -2412,6 +2641,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "license": "MIT"
@@ -2424,6 +2667,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2439,6 +2699,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -2578,6 +2848,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,22 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
+    "@xyflow/react": "^12.10.2",
     "html-to-image": "^1.11.11",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
-    "@xyflow/react": "^12.10.2",
     "uuid": "^14.0.0"
   },
   "scripts": {
     "dev": "vite",
     "start": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc -b --noEmit"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",
@@ -31,6 +34,7 @@
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/features/ili-explorer/services/IliParserService.ts
+++ b/src/features/ili-explorer/services/IliParserService.ts
@@ -41,7 +41,7 @@ export class IliParserService {
     const domainEnums = new Map<string, IliEnumValue[]>();
     
    
-    const domainSections = content.match(/DOMAIN\s*\n([\s\S]*?)(?=\s*(?:TOPIC|CLASS|END))/g) || [];
+    const domainSections = content.match(/DOMAIN\s*\n([\s\S]*?)(?=\s*\b(?:TOPIC|CLASS|END)\b)/g) || [];
     
     domainSections.forEach(section => {
      
@@ -164,12 +164,15 @@ export class IliParserService {
         continue;
       }
 
-     
-      const valueMatch = line.match(/([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/);
-      if (valueMatch) {
-        const value = valueMatch[1].trim();
-        const comment = this.extractComment(line) || currentComment;
-        
+      const inlineComment = this.extractComment(line);
+      const codePart = line.split('!!')[0];
+
+      const valueMatches = [...codePart.matchAll(/([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/g)];
+      for (const m of valueMatches) {
+        const value = m[1].trim();
+        if (!value) continue;
+        const comment = inlineComment || currentComment;
+
         const enumValue: IliEnumValue = {
           value,
           comment: comment || undefined
@@ -180,9 +183,9 @@ export class IliParserService {
         } else if (nestingLevel === 0) {
           values.push(enumValue);
         }
-
-        currentComment = '';
       }
+
+      if (valueMatches.length > 0) currentComment = '';
     }
 
     return values;
@@ -297,15 +300,20 @@ export class IliParserService {
             comment: this.extractComment(line, previousLine)
           };
         } else if (resolvedType.includes('(') && !resolvedType.includes('..')) {
-         
-          collectingEnum = true;
+          const closesOnSameLine = resolvedType.includes(')');
+          const insideParens = resolvedType.match(/\(([^)]*)\)/)?.[1] ?? '';
+          const inlineValues: IliEnumValue[] = [...insideParens.matchAll(/([a-zA-ZäöüÄÖÜß\w]+)/g)]
+            .map(m => ({ value: m[1].trim() }))
+            .filter(v => v.value.length > 0);
+
+          collectingEnum = !closesOnSameLine;
           currentAttribute = {
             name,
             type: 'ENUMERATION',
             mandatory,
             isEnum: true,
             isInlineEnum: true,
-            enumValues: [],
+            enumValues: inlineValues,
             comment: this.extractComment(line, previousLine)
           };
         } else {
@@ -346,23 +354,22 @@ export class IliParserService {
 
        
        
-        const enumValueMatch = line.match(/^\s*([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/);
-        if (enumValueMatch) {
-          const value = enumValueMatch[1].trim();
-          const comment = this.extractComment(line, previousLine);
-          
-         
+        const codePart = line.split('!!')[0];
+        const comment = this.extractComment(line, previousLine);
+        const valueMatches = [...codePart.matchAll(/([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/g)];
+
+        for (const m of valueMatches) {
+          const value = m[1].trim();
+          if (!value) continue;
           const fullValue = currentParent ? `${currentParent}.${value}` : value;
-          
-          const enumValue: IliEnumValue = { 
-            value: fullValue,
-            comment: comment || undefined 
-          };
-          
+
           if (!currentAttribute.enumValues) {
             currentAttribute.enumValues = [];
           }
-          currentAttribute.enumValues.push(enumValue);
+          currentAttribute.enumValues.push({
+            value: fullValue,
+            comment: comment || undefined
+          });
         }
       }
     }
@@ -707,12 +714,15 @@ export class IliParserService {
         continue;
       }
 
-     
-      const valueMatch = line.match(/([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/);
-      if (valueMatch) {
-        const value = valueMatch[1].trim();
-        const comment = this.extractComment(line) || currentComment;
-        
+      const inlineComment = this.extractComment(line);
+      const codePart = line.split('!!')[0];
+
+      const valueMatches = [...codePart.matchAll(/([a-zA-ZäöüÄÖÜß\w]+)\s*(?:,|$)/g)];
+      for (const m of valueMatches) {
+        const value = m[1].trim();
+        if (!value) continue;
+        const comment = inlineComment || currentComment;
+
         const enumValue: IliEnumValue = {
           value,
           comment: comment || undefined
@@ -723,11 +733,11 @@ export class IliParserService {
         } else if (nestingLevel === 0) {
           values.push(enumValue);
         }
-
-        currentComment = '';
       }
+
+      if (valueMatches.length > 0) currentComment = '';
     }
 
     return values;
   }
-} 
+}

--- a/src/features/ili-explorer/services/__tests__/IliLayoutService.test.ts
+++ b/src/features/ili-explorer/services/__tests__/IliLayoutService.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { IliParserService } from '../IliParserService';
+import { IliLayoutService } from '../IliLayoutService';
+import {
+  flowNodeFromBaseNode,
+  inheritanceEdgesFromRelations,
+} from '../flowMapping';
+import type { IliNode } from '../types/IliBaseTypes';
+import { mockColors, defaultLayoutOptions } from './testHelpers';
+
+function buildLayoutInput(ili: string) {
+  const { nodes: baseNodes, relations } = new IliParserService().parseContent(ili);
+  const flowNodes = baseNodes.map(flowNodeFromBaseNode) as IliNode[];
+  const flowEdges = inheritanceEdgesFromRelations(relations, mockColors, true);
+  return { flowNodes, flowEdges };
+}
+
+describe('IliLayoutService.getDirectRelations', () => {
+  it('returns just the entity if it has no relations', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Foo =
+            id : MANDATORY TEXT*10;
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { flowNodes, flowEdges } = buildLayoutInput(ili);
+    const foo = flowNodes.find(n => n.id === 'Foo')!;
+
+    const result = IliLayoutService.getDirectRelations(
+      foo,
+      flowNodes,
+      flowEdges,
+      mockColors,
+      defaultLayoutOptions,
+    );
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].id).toBe('Foo');
+    expect(result.nodes[0].data.isActive).toBe(true);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('places supertype above (negative y) and subtypes below (positive y)', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Base (ABSTRACT) =
+            id : MANDATORY TEXT*10;
+          END Base;
+          CLASS Mid EXTENDS Base =
+            extra : TEXT*40;
+          END Mid;
+          CLASS LeafA EXTENDS Mid =
+            a : TEXT*40;
+          END LeafA;
+          CLASS LeafB EXTENDS Mid =
+            b : TEXT*40;
+          END LeafB;
+        END T;
+      END Demo.
+    `;
+
+    const { flowNodes, flowEdges } = buildLayoutInput(ili);
+    const mid = flowNodes.find(n => n.id === 'Mid')!;
+
+    const result = IliLayoutService.getDirectRelations(
+      mid,
+      flowNodes,
+      flowEdges,
+      mockColors,
+      defaultLayoutOptions,
+    );
+
+    const ids = result.nodes.map(n => n.id);
+    expect(ids).toContain('Mid');
+    expect(ids).toContain('Base');
+    expect(ids).toContain('LeafA');
+    expect(ids).toContain('LeafB');
+
+    const yOf = (id: string) => result.nodes.find(n => n.id === id)!.position.y;
+    expect(yOf('Base')).toBeLessThan(yOf('Mid'));
+    expect(yOf('LeafA')).toBeGreaterThan(yOf('Mid'));
+    expect(yOf('LeafB')).toBeGreaterThan(yOf('Mid'));
+  });
+
+  it('attaches association nodes when showAssociations is true', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Owner =
+            name : MANDATORY TEXT*40;
+          END Owner;
+          CLASS Asset =
+            label : MANDATORY TEXT*40;
+          END Asset;
+          ASSOCIATION Owns =
+            ownerRef -- {1} Owner;
+            assetRef -- {0..*} Asset;
+          END Owns;
+        END T;
+      END Demo.
+    `;
+
+    const { flowNodes, flowEdges } = buildLayoutInput(ili);
+    const owner = flowNodes.find(n => n.id === 'Owner')!;
+
+    const result = IliLayoutService.getDirectRelations(
+      owner,
+      flowNodes,
+      flowEdges,
+      mockColors,
+      defaultLayoutOptions,
+    );
+
+    const assocNode = result.nodes.find(n => n.type === 'associationNode');
+    expect(assocNode).toBeDefined();
+    expect(assocNode?.data.label).toBe('Owns');
+  });
+
+  it('omits association nodes when showAssociations is false', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Owner =
+            name : MANDATORY TEXT*40;
+          END Owner;
+          CLASS Asset =
+            label : MANDATORY TEXT*40;
+          END Asset;
+          ASSOCIATION Owns =
+            ownerRef -- {1} Owner;
+            assetRef -- {0..*} Asset;
+          END Owns;
+        END T;
+      END Demo.
+    `;
+
+    const { flowNodes, flowEdges } = buildLayoutInput(ili);
+    const owner = flowNodes.find(n => n.id === 'Owner')!;
+
+    const result = IliLayoutService.getDirectRelations(
+      owner,
+      flowNodes,
+      flowEdges,
+      mockColors,
+      { ...defaultLayoutOptions, showAssociations: false },
+    );
+
+    expect(result.nodes.find(n => n.type === 'associationNode')).toBeUndefined();
+  });
+
+  it('returns deterministic edge ids across two runs (P0-2 regression)', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Base (ABSTRACT) =
+            id : MANDATORY TEXT*10;
+          END Base;
+          CLASS Sub EXTENDS Base =
+            extra : TEXT*40;
+          END Sub;
+        END T;
+      END Demo.
+    `;
+
+    const { flowNodes, flowEdges } = buildLayoutInput(ili);
+    const sub = flowNodes.find(n => n.id === 'Sub')!;
+
+    const a = IliLayoutService.getDirectRelations(sub, flowNodes, flowEdges, mockColors, defaultLayoutOptions);
+    const b = IliLayoutService.getDirectRelations(sub, flowNodes, flowEdges, mockColors, defaultLayoutOptions);
+
+    expect(a.edges.map(e => e.id).sort()).toEqual(b.edges.map(e => e.id).sort());
+  });
+
+  it('returns empty result for falsy entity / nodes / edges', () => {
+    const empty = IliLayoutService.getDirectRelations(
+      null as unknown as IliNode,
+      [],
+      [],
+      mockColors,
+      defaultLayoutOptions,
+    );
+    expect(empty.nodes).toEqual([]);
+    expect(empty.edges).toEqual([]);
+  });
+});

--- a/src/features/ili-explorer/services/__tests__/IliParserService.test.ts
+++ b/src/features/ili-explorer/services/__tests__/IliParserService.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import { IliParserService } from '../IliParserService';
+import type { IliClassNode } from '../types/IliModelTypes';
+
+function parse(content: string) {
+  return new IliParserService().parseContent(content);
+}
+
+describe('IliParserService.parseContent', () => {
+  it('parses a single class with one attribute', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Foo =
+            name : TEXT*40;
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const foo = nodes.find(n => n.name === 'Foo') as IliClassNode | undefined;
+
+    expect(foo).toBeDefined();
+    expect(foo?.type).toBe('CLASS');
+    expect(foo?.attributes).toHaveLength(1);
+    expect(foo?.attributes?.[0].name).toBe('name');
+    expect(foo?.attributes?.[0].mandatory).toBe(false);
+  });
+
+  it('marks MANDATORY attributes', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Foo =
+            name : MANDATORY TEXT*40;
+            note : TEXT*200;
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const foo = nodes.find(n => n.name === 'Foo') as IliClassNode | undefined;
+    const byName = (n: string) => foo?.attributes?.find(a => a.name === n);
+
+    expect(byName('name')?.mandatory).toBe(true);
+    expect(byName('note')?.mandatory).toBe(false);
+  });
+
+  it('captures (ABSTRACT) modifier and EXTENDS relation', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Base (ABSTRACT) =
+            id : MANDATORY TEXT*10;
+          END Base;
+          CLASS Sub EXTENDS Base =
+            extra : TEXT*40;
+          END Sub;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes, relations } = parse(ili);
+    const base = nodes.find(n => n.name === 'Base') as IliClassNode | undefined;
+    const sub = nodes.find(n => n.name === 'Sub') as IliClassNode | undefined;
+
+    expect(base?.isAbstract).toBe(true);
+    expect(sub?.isAbstract).toBe(false);
+
+    const inheritance = relations.find(r => r.type === 'EXTENDS');
+    expect(inheritance?.sourceId).toBe('Sub');
+    expect(inheritance?.targetId).toBe('Base');
+  });
+
+  it('matches qualified superclass names like Topic.Class (P0-3 regression)', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC OtherTopic =
+          CLASS Parent =
+            id : MANDATORY TEXT*10;
+          END Parent;
+        END OtherTopic;
+        TOPIC T =
+          CLASS Child EXTENDS OtherTopic.Parent =
+            extra : TEXT*40;
+          END Child;
+        END T;
+      END Demo.
+    `;
+
+    const { relations } = parse(ili);
+    const inh = relations.find(r => r.sourceId === 'Child');
+    expect(inh).toBeDefined();
+    expect(inh?.targetId).toContain('Parent');
+  });
+
+  it('parses an inline ENUMERATION attribute (multi-line values)', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Foo =
+            kind : (
+              red,
+              green,
+              blue
+            );
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const foo = nodes.find(n => n.name === 'Foo') as IliClassNode | undefined;
+    const kind = foo?.attributes?.find(a => a.name === 'kind');
+
+    expect(kind?.isEnum).toBe(true);
+    expect(kind?.isInlineEnum).toBe(true);
+    expect(kind?.enumValues?.map(v => v.value)).toEqual(['red', 'green', 'blue']);
+  });
+
+  it('parses an inline ENUMERATION attribute on a single line', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Foo =
+            kind : (red, green, blue);
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const foo = nodes.find(n => n.name === 'Foo') as IliClassNode | undefined;
+    const kind = foo?.attributes?.find(a => a.name === 'kind');
+
+    expect(kind?.isEnum).toBe(true);
+    expect(kind?.enumValues?.map(v => v.value)).toEqual(['red', 'green', 'blue']);
+  });
+
+  it('parses ASSOCIATION between two classes', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          CLASS Owner =
+            name : MANDATORY TEXT*40;
+          END Owner;
+          CLASS Asset =
+            label : MANDATORY TEXT*40;
+          END Asset;
+          ASSOCIATION Owns =
+            ownerRef -- {1} Owner;
+            assetRef -- {0..*} Asset;
+          END Owns;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const owner = nodes.find(n => n.name === 'Owner') as IliClassNode | undefined;
+    const asset = nodes.find(n => n.name === 'Asset') as IliClassNode | undefined;
+
+    expect(owner?.associations).toHaveLength(1);
+    expect(asset?.associations).toHaveLength(1);
+    const assoc = owner?.associations?.[0];
+    expect(assoc?.name).toBe('Owns');
+    expect(assoc?.sourceClass).toBe('Owner');
+    expect(assoc?.targetClass).toBe('Asset');
+    expect(assoc?.targetCardinality).toBe('0..*');
+  });
+
+  it('returns empty result for empty input', () => {
+    const { nodes, relations } = parse('');
+    expect(nodes).toEqual([]);
+    expect(relations).toEqual([]);
+  });
+
+  it('parses a top-level ENUMERATION definition (single-line values)', () => {
+    const ili = `
+      MODEL Demo =
+        TOPIC T =
+          ENUMERATION Color = (red, green, blue);
+          CLASS Foo =
+            id : MANDATORY TEXT*10;
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const enumNode = nodes.find(n => n.name === 'Color');
+
+    expect(enumNode?.type).toBe('enumNode');
+    expect(enumNode?.data.enumValues?.map((v: { value: string }) => v.value))
+      .toEqual(['red', 'green', 'blue']);
+  });
+
+  it('parses DOMAIN enumeration with EXTENDS and nested values', () => {
+    const ili = `
+      MODEL Demo =
+        DOMAIN
+          BaseEnum = (
+            a,
+            b,
+            c
+          );
+          ExtEnum EXTENDS BaseEnum = (
+            a (
+              a1,
+              a2
+            ),
+            b
+          );
+        TOPIC T =
+          CLASS Foo =
+            id : MANDATORY TEXT*10;
+          END Foo;
+        END T;
+      END Demo.
+    `;
+
+    const { nodes } = parse(ili);
+    const ext = nodes.find(n => n.id === 'domain_ExtEnum');
+
+    expect(ext).toBeDefined();
+    expect(ext?.type).toBe('domainEnumNode');
+    expect(ext?.data.extends).toBe('BaseEnum');
+  });
+});

--- a/src/features/ili-explorer/services/__tests__/testHelpers.ts
+++ b/src/features/ili-explorer/services/__tests__/testHelpers.ts
@@ -1,0 +1,42 @@
+import type { ThemeColors } from '../../../../common/theme/ThemeContext';
+import type { LayoutOptions } from '../types/IliBaseTypes';
+
+export const mockColors: ThemeColors = {
+  entity: '#000',
+  abstractEntity: '#000',
+  selectedEntity: '#000',
+  typeNode: '#000',
+  inheritance: '#000',
+  typeReference: '#000',
+  nodeSection: '#000',
+  nodeContent: '#000',
+  background: '#000',
+  paper: '#000',
+  console: '#000',
+  codeViewer: '#000',
+  minimap: '#000',
+  success: '#000',
+  appBar: '#000',
+  primary: '#000',
+  secondary: '#000',
+  active: '#000',
+  text: '#000',
+  propertyText: '#000',
+  primaryText: '#000',
+  secondaryText: '#000',
+  scrollbar: { track: '#000', thumb: '#000', thumbHover: '#000' },
+  shadow: '#000',
+  relationship: '#000',
+  reference: '#000',
+  selectedNodeBg: '#000',
+  nodeHeaderText: '#000',
+};
+
+export const defaultLayoutOptions: LayoutOptions = {
+  showFullHierarchy: true,
+  useCurvedLines: true,
+  showEnums: true,
+  showAssociations: true,
+  maxSubTypesPerRow: 4,
+  useMagicLayout: false,
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
Test setup
- Add vitest 4.1.5 as devDependency.
- vitest.config.ts: node environment, src/**/*.test.ts(x) glob.
- package.json scripts: test, test:watch, typecheck (separate from the build-bundling step).
- Co-locate tests under src/features/ili-explorer/services/__tests__: testHelpers.ts (mock ThemeColors + default LayoutOptions), IliParserService.test.ts (10 tests), IliLayoutService.test.ts (6 tests). 16 tests run in ~120 ms.
- Layout test pins the deterministic-edge-id fix from P0-2 as a regression guard.

Parser bugs the tests uncovered (all latent on real .ili files, not introduced by these changes)
- parseEnumValues / parseNestedEnumValues only captured the first value when an enum body sat on a single line, e.g. `AxisPositionCode = (plus, minus, equal);` (real pattern in Axis_V1_1.ili) yielded just `[plus]`. Switched to matchAll over the code part of each line so every comma-separated identifier is collected.
- parseAttributes lost all values when an inline class enum was written on one line (`kind : (red, green, blue);`): attrMatch consumed the whole `(...)`, then the line-by-line collector ran on the *next* line and found nothing. Now: if the parens close on the same line, parse the values directly from the captured type and skip the multi-line collector.
- The DOMAIN section regex stopped mid-`EXTENDS` because the lookahead matched `END` as a substring. Adding word boundaries around TOPIC|CLASS|END (`\b(?:TOPIC|CLASS|END)\b`) makes the section span the full block, so `ExtEnum EXTENDS BaseEnum = (...)` is now recognized as a domain enumeration.