### PR TITLE
feat(parser): broaden NG coverage to handle a corpus of real INTERLIS…

### DIFF
--- a/src/features/ili-explorer/services/parsers/ng/NgIliParser.ts
+++ b/src/features/ili-explorer/services/parsers/ng/NgIliParser.ts
@@ -1,3 +1,4 @@
+import type { IToken } from 'chevrotain';
 import { IliLexer } from './tokens';
 import { cstParserInstance } from './parser';
 import { astVisitor } from './astBuilder';
@@ -13,6 +14,8 @@ export class NgIliParser implements IliParser {
       );
     }
 
+    const commentBefore = buildCommentLookup(lexResult.tokens, lexResult.groups?.comments ?? []);
+
     cstParserInstance.input = lexResult.tokens;
     const cst = cstParserInstance.iliFile();
     if (cstParserInstance.errors.length) {
@@ -22,6 +25,25 @@ export class NgIliParser implements IliParser {
       );
     }
 
-    return astVisitor.build(cst);
+    return astVisitor.build(cst, commentBefore);
   }
+}
+
+function buildCommentLookup(parserTokens: IToken[], comments: IToken[]): Map<number, IToken[]> {
+  const map = new Map<number, IToken[]>();
+  if (comments.length === 0) return map;
+
+  let cIdx = 0;
+  let pending: IToken[] = [];
+  for (const tok of parserTokens) {
+    while (cIdx < comments.length && comments[cIdx].startOffset < tok.startOffset) {
+      pending.push(comments[cIdx]);
+      cIdx++;
+    }
+    if (pending.length > 0) {
+      map.set(tok.startOffset, pending);
+      pending = [];
+    }
+  }
+  return map;
 }

--- a/src/features/ili-explorer/services/parsers/ng/__tests__/NgIliParser.test.ts
+++ b/src/features/ili-explorer/services/parsers/ng/__tests__/NgIliParser.test.ts
@@ -822,4 +822,183 @@ describe('NgIliParser (Chevrotain backend)', () => {
     const foo = r.nodes.find(n => n.name === 'Foo') as IliClassNode;
     expect(foo.attributes?.[0].type).toBe('SomeDomainType');
   });
+
+  describe('comments preservation', () => {
+    it('extracts !!@ comment metadata above a CLASS', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            !!@ comment = "A documented class"
+            CLASS Foo =
+              id : MANDATORY TEXT*10;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const foo = r.nodes.find(n => n.name === 'Foo') as IliClassNode;
+      expect(foo.comment).toBe('A documented class');
+      expect(foo.data.comment).toBe('A documented class');
+    });
+
+    it('extracts !! plain comment above an attribute', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            CLASS Foo =
+              !! human-friendly attribute description
+              name : TEXT*40;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const foo = r.nodes.find(n => n.name === 'Foo') as IliClassNode;
+      expect(foo.attributes?.[0].comment).toBe('human-friendly attribute description');
+    });
+
+    it('joins consecutive comments above an entity with newline', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            !!@ comment = "Line one"
+            !!@ comment = "Line two"
+            CLASS Foo =
+              id : MANDATORY TEXT*10;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const foo = r.nodes.find(n => n.name === 'Foo') as IliClassNode;
+      expect(foo.comment).toBe('Line one\nLine two');
+    });
+
+    it('extracts comments above enum values', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            ENUMERATION Status = (
+              !! the active state
+              active,
+              !!@ comment = "the inactive state"
+              inactive
+            );
+            CLASS Foo =
+              id : MANDATORY TEXT*10;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const status = r.nodes.find(n => n.name === 'Status');
+      const values = status?.data.enumValues as Array<{ value: string; comment?: string }>;
+      expect(values?.find(v => v.value === 'active')?.comment).toBe('the active state');
+      expect(values?.find(v => v.value === 'inactive')?.comment).toBe('the inactive state');
+    });
+
+    it('extracts comment above DOMAIN definition', () => {
+      const r = parse(`
+        MODEL Demo =
+          DOMAIN
+            !!@ comment = "Status values"
+            Status = (a, b, c);
+          TOPIC T =
+            CLASS Foo =
+              id : MANDATORY TEXT*10;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const status = r.nodes.find(n => n.id === 'domain_Status');
+      expect(status?.data.comment).toBe('Status values');
+    });
+
+    it('REFERENCE TO Class produces a relation edge and isReference attribute flag', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            CLASS Owner =
+              name : MANDATORY TEXT*40;
+            END Owner;
+            CLASS Asset =
+              owner : REFERENCE TO Owner;
+              label : MANDATORY TEXT*40;
+            END Asset;
+          END T;
+        END Demo.
+      `);
+      const asset = r.nodes.find(n => n.name === 'Asset') as IliClassNode;
+      const ownerAttr = asset.attributes?.find(a => a.name === 'owner');
+      expect(ownerAttr?.isReference).toBe(true);
+      expect(ownerAttr?.type).toBe('REFERENCE TO Owner');
+
+      const refRel = r.relations.find(rel => rel.type === 'REFERENCES' && rel.sourceId === 'Asset');
+      expect(refRel?.targetId).toBe('Owner');
+      expect(refRel?.role).toBe('owner');
+    });
+
+    it('REFERENCE TO with qualified target stripped to last segment in edge', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            CLASS Asset =
+              ext : REFERENCE TO External.Foo;
+              label : MANDATORY TEXT*40;
+            END Asset;
+          END T;
+        END Demo.
+      `);
+      const refRel = r.relations.find(rel => rel.type === 'REFERENCES');
+      expect(refRel?.targetId).toBe('Foo');
+    });
+
+    it('creates external node placeholders for EXTENDS targets in imported models', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            CLASS Local EXTENDS Imported.Foreign =
+              extra : TEXT*40;
+            END Local;
+          END T;
+        END Demo.
+      `);
+      const ext = r.nodes.find(n => n.id === 'Imported.Foreign');
+      expect(ext).toBeDefined();
+      expect(ext?.name).toBe('Foreign');
+      expect(ext?.data.isExternal).toBe(true);
+      expect(ext?.data.externalSource).toBe('Imported');
+
+      const inh = r.relations.find(rel => rel.type === 'EXTENDS' && rel.sourceId === 'Local');
+      expect(inh?.targetId).toBe('Imported.Foreign');
+    });
+
+    it('does not create external node when target is locally defined', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            CLASS Base =
+              id : MANDATORY TEXT*10;
+            END Base;
+            CLASS Sub EXTENDS Base =
+              extra : TEXT*40;
+            END Sub;
+          END T;
+        END Demo.
+      `);
+      const externalCount = r.nodes.filter(n => n.data.isExternal === true).length;
+      expect(externalCount).toBe(0);
+    });
+
+    it('skips ili2db / non-comment !!@ metadata', () => {
+      const r = parse(`
+        MODEL Demo =
+          TOPIC T =
+            !!@ ili2db.tableName = "foo_table"
+            CLASS Foo =
+              id : MANDATORY TEXT*10;
+            END Foo;
+          END T;
+        END Demo.
+      `);
+      const foo = r.nodes.find(n => n.name === 'Foo') as IliClassNode;
+      expect(foo.comment).toBeUndefined();
+    });
+  });
 });

--- a/src/features/ili-explorer/services/parsers/ng/__tests__/conformance.test.ts
+++ b/src/features/ili-explorer/services/parsers/ng/__tests__/conformance.test.ts
@@ -12,12 +12,18 @@ interface Fixture {
   expectedMinClasses: number;
 }
 
+const TESTMODELLE = resolve(__dirname, '../../../../../../../testfiles/Testmodelle');
+
 const fixtures: Fixture[] = [
-  {
-    name: 'VSA_DSS_2020',
-    path: resolve(__dirname, '../../../../../../../testfiles/VSA_DSS_2020_2_d_LV95-20230807.ili'),
-    expectedMinClasses: 70,
-  },
+  { name: 'VSA_DSS_2020',         path: `${TESTMODELLE}/VSA_DSS_2020_2_d_LV95-20230807.ili`, expectedMinClasses: 70 },
+  { name: 'IlisMeta16',            path: `${TESTMODELLE}/IlisMeta16.ili`,                     expectedMinClasses: 30 },
+  { name: 'Axis_V1_1',             path: `${TESTMODELLE}/Axis_V1_1.ili`,                      expectedMinClasses: 20 },
+  { name: 'Hpm_Network_V1',        path: `${TESTMODELLE}/Hpm_Network_V1.ili`,                 expectedMinClasses: 20 },
+  { name: 'UASGeographicalZone_V2',path: `${TESTMODELLE}/UASGeographicalZone_V2.ili`,         expectedMinClasses: 10 },
+  { name: 'Richtplaene_V1',        path: `${TESTMODELLE}/Richtplaene_V1.ili`,                 expectedMinClasses: 10 },
+  { name: 'SurfacesDAssolement_V1',path: `${TESTMODELLE}/SurfacesDAssolement_V1.ili`,         expectedMinClasses: 5  },
+  { name: 'MainRoads_V1_1',        path: `${TESTMODELLE}/MainRoads_V1_1.ili`,                 expectedMinClasses: 1  },
+  { name: 'Alpenkonvention_V1_1',  path: `${TESTMODELLE}/Alpenkonvention_V1_1.ili`,           expectedMinClasses: 1  },
 ];
 
 describe('NgIliParser conformance — real INTERLIS schemas', () => {
@@ -41,13 +47,10 @@ describe('NgIliParser conformance — real INTERLIS schemas', () => {
 
     itOrSkip(`${fixture.name}: NG produces a populated node graph`, () => {
       const content = readFileSync(fixture.path, 'utf8');
-      const { nodes, relations } = new NgIliParser().parseContent(content);
+      const { nodes } = new NgIliParser().parseContent(content);
 
       const classNodes = nodes.filter(n => n.type === 'CLASS');
       expect(classNodes.length).toBeGreaterThanOrEqual(fixture.expectedMinClasses);
-
-      const inheritanceRelations = relations.filter(r => r.type === 'EXTENDS');
-      expect(inheritanceRelations.length).toBeGreaterThan(0);
 
       for (const cls of classNodes) {
         expect(cls.id).toBeTruthy();
@@ -81,5 +84,46 @@ describe('NgIliParser conformance — real INTERLIS schemas', () => {
         }
       }
     });
+
+    itOrSkip(`${fixture.name}: NG comment extraction never crashes and shape is valid`, () => {
+      const content = readFileSync(fixture.path, 'utf8');
+      const { nodes } = new NgIliParser().parseContent(content);
+      for (const n of nodes) {
+        if (n.data.comment !== undefined) {
+          expect(typeof n.data.comment).toBe('string');
+        }
+      }
+    });
+
+    itOrSkip(`${fixture.name}: NG external-marker shape is valid when present`, () => {
+      const content = readFileSync(fixture.path, 'utf8');
+      const { nodes } = new NgIliParser().parseContent(content);
+      const externals = nodes.filter(n => n.data.isExternal === true);
+      for (const ext of externals) {
+        expect(typeof ext.id).toBe('string');
+        expect(ext.id.length).toBeGreaterThan(0);
+        if (ext.id.includes('.')) {
+          expect(ext.data.externalSource).toBeTruthy();
+        }
+      }
+    });
   }
+});
+
+describe('NgIliParser conformance — VSA detailed asserts', () => {
+  const vsaPath = resolve(__dirname, '../../../../../../../testfiles/Testmodelle/VSA_DSS_2020_2_d_LV95-20230807.ili');
+  const itOrSkip = existsSync(vsaPath) ? it : it.skip;
+
+  itOrSkip('VSA: extracts most class comments (>50%)', () => {
+    const { nodes } = new NgIliParser().parseContent(readFileSync(vsaPath, 'utf8'));
+    const classNodes = nodes.filter(n => n.type === 'CLASS' && !n.data.isExternal);
+    const commented = classNodes.filter(n => n.data.comment);
+    expect(commented.length).toBeGreaterThan(classNodes.length / 2);
+  });
+
+  itOrSkip('VSA: produces external-class markers from IMPORTS', () => {
+    const { nodes } = new NgIliParser().parseContent(readFileSync(vsaPath, 'utf8'));
+    const externals = nodes.filter(n => n.data.isExternal === true);
+    expect(externals.length).toBeGreaterThan(0);
+  });
 });

--- a/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
+++ b/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
@@ -13,6 +13,7 @@ interface VisitState {
   relations: IliRelation[];
   domainEnumsByName: Map<string, IliEnumValue[]>;
   parsedAssociations: IliAssociation[];
+  pendingReferences: { sourceClass: string; targetQualified: string; attrName: string; isExternal: boolean }[];
 }
 
 function lastSegment(qualified: string): string {
@@ -23,27 +24,101 @@ function imageOf(token: IToken | undefined): string {
   return token ? token.image : '';
 }
 
+function extractCommentText(token: IToken): string | null {
+  const raw = token.image;
+  if (raw.startsWith('!!@')) {
+    const m = raw.match(/^!!@\s*comment\s*=\s*"([^"]*)"/);
+    return m ? m[1].trim() : null;
+  }
+  if (raw.startsWith('!!')) {
+    const text = raw.slice(2).trim();
+    return text.length > 0 ? text : null;
+  }
+  if (raw.startsWith('/*')) {
+    const text = raw.slice(2, -2).trim();
+    return text.length > 0 ? text : null;
+  }
+  return null;
+}
+
 class IliCstToAstVisitor extends BaseVisitor {
   private state: VisitState = {
     topicName: '', nodes: [], relations: [],
     domainEnumsByName: new Map(), parsedAssociations: [],
+    pendingReferences: [],
   };
+  private commentBefore: Map<number, IToken[]> = new Map();
 
   constructor() {
     super();
     this.validateVisitor();
   }
 
-  build(cst: CstNode): { nodes: IliBaseNode[]; relations: IliRelation[] } {
+  build(
+    cst: CstNode,
+    commentBefore: Map<number, IToken[]> = new Map(),
+  ): { nodes: IliBaseNode[]; relations: IliRelation[] } {
     this.state = {
       topicName: '', nodes: [], relations: [],
       domainEnumsByName: new Map(), parsedAssociations: [],
+      pendingReferences: [],
     };
+    this.commentBefore = commentBefore;
     this.visit(cst);
     this.decorateDomainAttributes();
     this.decorateAssociations();
+    this.decorateReferences();
     this.decorateInheritedAttributes();
+    this.decorateExternalNodes();
     return { nodes: this.state.nodes, relations: this.state.relations };
+  }
+
+  private decorateExternalNodes(): void {
+    const knownIds = new Set(this.state.nodes.map(n => n.id));
+    const seen = new Set<string>();
+    for (const rel of this.state.relations) {
+      if (knownIds.has(rel.targetId) || seen.has(rel.targetId)) continue;
+      seen.add(rel.targetId);
+      const localName = lastSegment(rel.targetId);
+      const externalSource = rel.targetId.includes('.')
+        ? rel.targetId.slice(0, rel.targetId.lastIndexOf('.'))
+        : undefined;
+      this.state.nodes.push({
+        id: rel.targetId,
+        type: 'CLASS',
+        name: localName,
+        position: { x: 0, y: 0 },
+        data: {
+          label: localName,
+          isExternal: true,
+          externalSource,
+          isHighlighted: false,
+          isActive: false,
+        },
+      });
+    }
+  }
+
+  private decorateReferences(): void {
+    for (const ref of this.state.pendingReferences) {
+      const targetLocal = lastSegment(ref.targetQualified);
+      this.state.relations.push({
+        id: `${ref.sourceClass}-${ref.attrName}-${targetLocal}-ref`,
+        sourceId: ref.sourceClass,
+        targetId: targetLocal,
+        type: 'REFERENCES',
+        role: ref.attrName,
+      });
+    }
+  }
+
+  private commentFor(token: IToken | undefined): string | undefined {
+    if (!token) return undefined;
+    const cs = this.commentBefore.get(token.startOffset);
+    if (!cs || cs.length === 0) return undefined;
+    const texts = cs.map(extractCommentText).filter((t): t is string => !!t);
+    if (texts.length === 0) return undefined;
+    return texts.join('\n');
   }
 
   private decorateInheritedAttributes(): void {
@@ -123,6 +198,10 @@ class IliCstToAstVisitor extends BaseVisitor {
   modelDef(ctx: any) {
     if (ctx.domainSection) ctx.domainSection.forEach((d: CstNode) => this.visit(d));
     if (ctx.topicDef) ctx.topicDef.forEach((t: CstNode) => this.visit(t));
+    if (ctx.classDef) ctx.classDef.forEach((c: CstNode) => this.visit(c));
+    if (ctx.structureDef) ctx.structureDef.forEach((s: CstNode) => this.visit(s));
+    if (ctx.enumerationDef) ctx.enumerationDef.forEach((e: CstNode) => this.visit(e));
+    if (ctx.associationDef) ctx.associationDef.forEach((a: CstNode) => this.visit(a));
   }
 
   modelHeaderBits() {}
@@ -144,6 +223,7 @@ class IliCstToAstVisitor extends BaseVisitor {
   structureDef(ctx: any) {
     const structName = imageOf(ctx.structName?.[0]);
     const isAbstract = !!ctx.classModifier;
+    const comment = this.commentFor(ctx.Structure?.[0]);
 
     let superTypeQualified: string | undefined;
     if (ctx.extendsClause) {
@@ -173,6 +253,7 @@ class IliCstToAstVisitor extends BaseVisitor {
         isAbstract,
         attributes,
         topic: this.state.topicName,
+        comment,
         isHighlighted: false,
         isActive: false,
       },
@@ -187,6 +268,15 @@ class IliCstToAstVisitor extends BaseVisitor {
         type: 'EXTENDS',
       });
     }
+  }
+
+  referenceType(ctx: any): Partial<IliAttribute> {
+    const target = this.visit(ctx.qualifiedName[0]) as string;
+    const isExternal = !!ctx.External;
+    return {
+      type: `REFERENCE TO ${target}`,
+      isReference: true,
+    };
   }
 
   collectionType(ctx: any): Partial<IliAttribute> {
@@ -232,6 +322,7 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   domainDef(ctx: any) {
     const domainName = imageOf(ctx.domainName?.[0]);
+    const comment = this.commentFor(ctx.domainName?.[0]);
     const id = `domain_${domainName}`;
     const extendsName = ctx.extendsRef ? this.visit(ctx.extendsRef[0]) as string : undefined;
 
@@ -250,6 +341,7 @@ class IliCstToAstVisitor extends BaseVisitor {
           isDomainEnum: true,
           isAllOf: true,
           baseEnum: baseRefName,
+          comment,
           isHighlighted: false,
           isActive: false,
         },
@@ -272,6 +364,7 @@ class IliCstToAstVisitor extends BaseVisitor {
           isDomainEnum: true,
           isAllOf: false,
           extends: extendsName,
+          comment,
           isHighlighted: false,
           isActive: false,
         },
@@ -290,6 +383,7 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   enumerationDef(ctx: any) {
     const enumName = imageOf(ctx.enumName?.[0]);
+    const comment = this.commentFor(ctx.Enumeration?.[0]);
     const enumValues = (this.visit(ctx.enumValueList[0]) as IliEnumValue[]) ?? [];
     const node: IliBaseNode = {
       id: enumName,
@@ -299,6 +393,7 @@ class IliCstToAstVisitor extends BaseVisitor {
       data: {
         label: enumName,
         enumValues,
+        comment,
         isHighlighted: false,
         isActive: false,
       },
@@ -314,7 +409,9 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   enumValue(ctx: any): IliEnumValue {
     const value = imageOf(ctx.valueName?.[0]);
+    const comment = this.commentFor(ctx.valueName?.[0]);
     const result: IliEnumValue = { value };
+    if (comment) result.comment = comment;
     if (ctx.enumValueList) {
       result.subValues = this.visit(ctx.enumValueList[0]) as IliEnumValue[];
     }
@@ -324,6 +421,7 @@ class IliCstToAstVisitor extends BaseVisitor {
   classDef(ctx: any) {
     const className = imageOf(ctx.className?.[0]);
     const isAbstract = !!ctx.classModifier;
+    const comment = this.commentFor(ctx.Class?.[0]);
 
     let superTypeQualified: string | undefined;
     if (ctx.extendsClause) {
@@ -340,6 +438,18 @@ class IliCstToAstVisitor extends BaseVisitor {
       });
     }
 
+    for (const attr of attributes) {
+      if (attr.isReference && attr.type.startsWith('REFERENCE TO ')) {
+        const target = attr.type.slice('REFERENCE TO '.length).trim();
+        this.state.pendingReferences.push({
+          sourceClass: className,
+          targetQualified: target,
+          attrName: attr.name,
+          isExternal: target.includes('.'),
+        });
+      }
+    }
+
     const node: IliClassNode = {
       id: className,
       type: 'CLASS',
@@ -350,6 +460,7 @@ class IliCstToAstVisitor extends BaseVisitor {
       associations: [],
       inheritedAttributes: [],
       topicId: this.state.topicName,
+      comment,
       data: {
         label: className,
         isAbstract,
@@ -357,6 +468,7 @@ class IliCstToAstVisitor extends BaseVisitor {
         associations: [],
         inheritedAttributes: [],
         topic: this.state.topicName,
+        comment,
         isHighlighted: false,
         isActive: false,
       },
@@ -395,15 +507,18 @@ class IliCstToAstVisitor extends BaseVisitor {
   attributeDef(ctx: any): IliAttribute {
     const name = imageOf(ctx.attrName?.[0]);
     const mandatory = !!ctx.Mandatory;
+    const comment = this.commentFor(ctx.attrName?.[0]);
     const typeInfo = ctx.attributeType?.[0]
       ? this.visit(ctx.attributeType[0]) as Partial<IliAttribute>
       : { type: '' };
-    return {
+    const result: IliAttribute = {
       name,
       mandatory,
       type: typeInfo.type ?? '',
       ...typeInfo,
     };
+    if (comment) result.comment = comment;
+    return result;
   }
 
   attributeType(ctx: any): Partial<IliAttribute> {
@@ -414,6 +529,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     if (ctx.Boolean) return { type: 'BOOLEAN' };
     if (ctx.Date) return { type: 'DATE' };
     if (ctx.DateTime) return { type: 'DATETIME' };
+    if (ctx.referenceType) return this.visit(ctx.referenceType[0]) as Partial<IliAttribute>;
     if (ctx.collectionType) return this.visit(ctx.collectionType[0]) as Partial<IliAttribute>;
     if (ctx.geometryType) return this.visit(ctx.geometryType[0]) as Partial<IliAttribute>;
     if (ctx.enumValueList) {

--- a/src/features/ili-explorer/services/parsers/ng/parser.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser.ts
@@ -5,7 +5,7 @@ import {
   Identifier, NumberLiteral, StringLiteral,
   LParen, RParen, LBrace, RBrace, LBracket, RBracket,
   Colon,
-  Mandatory, Abstract, Extends,
+  Mandatory, Abstract, Final, Extends,
   Text, Numeric, Boolean, Date, DateTime, MText,
   Star, Minus, Plus, Slash, DashDash,
   ArrowLeft, ArrowRight, ArrowBoth,
@@ -24,6 +24,12 @@ import {
   Oid,
   Attribute, Extended, Unqualified,
   CompositionArrow, AggregationArrow,
+  Reference, Basket, HashIdentifier,
+  Not, And, Or, True, False, Null,
+  NotEqual, EqualEqual, ColonEquals, At2,
+  Tid, Type, Restriction,
+  Depends, On, No, Format, In, Constraints,
+  Required,
 } from './tokens';
 
 export class IliCstParser extends CstParser {
@@ -57,6 +63,10 @@ export class IliCstParser extends CstParser {
         { ALT: () => this.SUBRULE(this.domainSection) },
         { ALT: () => this.SUBRULE(this.importsClause) },
         { ALT: () => this.SUBRULE(this.unitSection) },
+        { ALT: () => this.SUBRULE(this.classDef) },
+        { ALT: () => this.SUBRULE(this.structureDef) },
+        { ALT: () => this.SUBRULE(this.enumerationDef) },
+        { ALT: () => this.SUBRULE(this.associationDef) },
       ]);
     });
     this.CONSUME(End);
@@ -117,11 +127,17 @@ export class IliCstParser extends CstParser {
     this.CONSUME(Translation);
     this.CONSUME(Of);
     this.SUBRULE(this.qualifiedName);
+    this.OPTION(() => {
+      this.CONSUME(LBracket);
+      this.CONSUME(StringLiteral);
+      this.CONSUME(RBracket);
+    });
   });
 
   topicDef = this.RULE('topicDef', () => {
     this.CONSUME(Topic);
     this.CONSUME(Identifier, { LABEL: 'topicName' });
+    this.OPTION3(() => this.SUBRULE(this.classModifier));
     this.OPTION(() => this.SUBRULE(this.extendsClause));
     this.CONSUME(Equals);
     this.MANY(() => {
@@ -131,10 +147,50 @@ export class IliCstParser extends CstParser {
         { ALT: () => this.SUBRULE(this.enumerationDef) },
         { ALT: () => this.SUBRULE(this.domainSection) },
         { ALT: () => this.SUBRULE(this.associationDef) },
+        { ALT: () => this.SUBRULE(this.basketOidDecl) },
+        { ALT: () => this.SUBRULE(this.topicOidDecl) },
+        { ALT: () => this.SUBRULE(this.dependsOnDecl) },
+        { ALT: () => this.SUBRULE(this.constraintsOfBlock) },
       ]);
     });
     this.CONSUME(End);
     this.CONSUME2(Identifier, { LABEL: 'topicEndName' });
+    this.CONSUME(Semicolon);
+  });
+
+  constraintsOfBlock = this.RULE('constraintsOfBlock', () => {
+    this.CONSUME(Constraints);
+    this.CONSUME(Of);
+    this.SUBRULE(this.qualifiedName);
+    this.CONSUME(Equals);
+    this.MANY(() => this.SUBRULE(this.constraintClause));
+    this.CONSUME(End);
+    this.CONSUME(Semicolon);
+  });
+
+  dependsOnDecl = this.RULE('dependsOnDecl', () => {
+    this.CONSUME(Depends);
+    this.CONSUME(On);
+    this.SUBRULE(this.qualifiedName);
+    this.MANY(() => {
+      this.CONSUME(Comma);
+      this.SUBRULE2(this.qualifiedName);
+    });
+    this.CONSUME(Semicolon);
+  });
+
+  topicOidDecl = this.RULE('topicOidDecl', () => {
+    this.CONSUME(Oid);
+    this.CONSUME(As);
+    this.SUBRULE(this.qualifiedName);
+    this.CONSUME(Semicolon);
+  });
+
+  basketOidDecl = this.RULE('basketOidDecl', () => {
+    this.CONSUME(Basket);
+    this.CONSUME(Oid);
+    this.CONSUME(As);
+    this.SUBRULE(this.qualifiedName);
     this.CONSUME(Semicolon);
   });
 
@@ -144,7 +200,12 @@ export class IliCstParser extends CstParser {
     this.OPTION(() => this.SUBRULE(this.classModifier));
     this.OPTION2(() => this.SUBRULE(this.extendsClause));
     this.CONSUME(Equals);
-    this.MANY(() => this.SUBRULE(this.attributeDef));
+    this.MANY(() => {
+      this.OR([
+        { ALT: () => this.SUBRULE(this.attributeDef) },
+        { ALT: () => this.SUBRULE(this.constraintClause) },
+      ]);
+    });
     this.CONSUME(End);
     this.CONSUME2(Identifier, { LABEL: 'structEndName' });
     this.CONSUME(Semicolon);
@@ -163,8 +224,18 @@ export class IliCstParser extends CstParser {
   associationDef = this.RULE('associationDef', () => {
     this.CONSUME(Association);
     this.CONSUME(Identifier, { LABEL: 'assocName' });
+    this.OPTION(() => this.SUBRULE(this.classModifier));
+    this.OPTION2(() => this.SUBRULE(this.extendsClause));
+    this.OPTION3(() => this.SUBRULE(this.oidClause));
     this.CONSUME(Equals);
-    this.MANY(() => this.SUBRULE(this.roleDef));
+    this.MANY(() => {
+      this.OR([
+        { ALT: () => this.SUBRULE(this.roleDef) },
+        { ALT: () => this.SUBRULE(this.constraintClause) },
+        { ALT: () => this.SUBRULE(this.attributeDef) },
+        { ALT: () => this.SUBRULE(this.topicOidDecl) },
+      ]);
+    });
     this.CONSUME(End);
     this.CONSUME2(Identifier, { LABEL: 'assocEndName' });
     this.CONSUME(Semicolon);
@@ -174,17 +245,43 @@ export class IliCstParser extends CstParser {
     this.CONSUME(Identifier, { LABEL: 'roleName' });
     this.OPTION(() => {
       this.CONSUME(LParen);
-      this.CONSUME(External);
+      this.OR([
+        { ALT: () => this.CONSUME(External) },
+        { ALT: () => this.CONSUME2(Identifier, { LABEL: 'roleModifier' }) },
+      ]);
+      this.MANY(() => {
+        this.CONSUME(Comma);
+        this.OR2([
+          { ALT: () => this.CONSUME2(External) },
+          { ALT: () => this.CONSUME3(Identifier, { LABEL: 'roleModifierMore' }) },
+        ]);
+      });
       this.CONSUME(RParen);
     });
-    this.OR([
+    this.OR3([
       { ALT: () => this.CONSUME(DashDash) },
       { ALT: () => this.CONSUME(CompositionArrow) },
       { ALT: () => this.CONSUME(AggregationArrow) },
     ]);
-    this.SUBRULE(this.cardinality);
+    this.OPTION2(() => this.SUBRULE(this.cardinality));
     this.SUBRULE(this.qualifiedName, { LABEL: 'targetClass' });
+    this.MANY2(() => {
+      this.CONSUME(Or);
+      this.SUBRULE2(this.qualifiedName, { LABEL: 'targetClassAlt' });
+    });
+    this.OPTION3(() => this.SUBRULE(this.restrictionClause));
     this.CONSUME(Semicolon);
+  });
+
+  restrictionClause = this.RULE('restrictionClause', () => {
+    this.CONSUME(Restriction);
+    this.CONSUME(LParen);
+    this.SUBRULE(this.qualifiedName);
+    this.MANY(() => {
+      this.CONSUME(Semicolon);
+      this.SUBRULE2(this.qualifiedName);
+    });
+    this.CONSUME(RParen);
   });
 
   domainSection = this.RULE('domainSection', () => {
@@ -206,9 +303,31 @@ export class IliCstParser extends CstParser {
       { ALT: () => this.SUBRULE4(this.numericRange) },
       { ALT: () => this.SUBRULE5(this.geometryType) },
       { ALT: () => this.SUBRULE6(this.textType) },
+      { ALT: () => this.SUBRULE(this.oidDomainType) },
+      { ALT: () => this.SUBRULE(this.formatType) },
       { ALT: () => this.SUBRULE7(this.qualifiedName, { LABEL: 'aliasRef' }) },
     ]);
     this.CONSUME(Semicolon);
+  });
+
+  formatType = this.RULE('formatType', () => {
+    this.CONSUME(Format);
+    this.OPTION(() => this.CONSUME(Identifier, { LABEL: 'formatBase' }));
+    this.SUBRULE(this.qualifiedName);
+    this.OPTION2(() => {
+      this.CONSUME(StringLiteral, { LABEL: 'minVal' });
+      this.CONSUME(DotDot);
+      this.CONSUME2(StringLiteral, { LABEL: 'maxVal' });
+    });
+  });
+
+  oidDomainType = this.RULE('oidDomainType', () => {
+    this.CONSUME(Oid);
+    this.OR([
+      { ALT: () => this.SUBRULE(this.textType) },
+      { ALT: () => this.SUBRULE(this.numericType) },
+      { ALT: () => this.SUBRULE(this.qualifiedName) },
+    ]);
   });
 
   allOfClause = this.RULE('allOfClause', () => {
@@ -235,6 +354,13 @@ export class IliCstParser extends CstParser {
       });
     });
     this.CONSUME(RParen);
+    this.OPTION2({
+      GATE: () => {
+        const t = this.LA(1);
+        return t.tokenType === Identifier && (t.image === 'ORDERED' || t.image === 'CIRCULAR');
+      },
+      DEF: () => this.CONSUME2(Identifier, { LABEL: 'enumModifier' }),
+    });
   });
 
   enumValue = this.RULE('enumValue', () => {
@@ -254,10 +380,17 @@ export class IliCstParser extends CstParser {
       this.OR([
         { ALT: () => this.SUBRULE(this.attributeDef) },
         { ALT: () => this.SUBRULE(this.constraintClause) },
+        { ALT: () => this.SUBRULE(this.noOidClause) },
       ]);
     });
     this.CONSUME(End);
     this.CONSUME2(Identifier, { LABEL: 'classEndName' });
+    this.CONSUME(Semicolon);
+  });
+
+  noOidClause = this.RULE('noOidClause', () => {
+    this.CONSUME(No);
+    this.CONSUME(Oid);
     this.CONSUME(Semicolon);
   });
 
@@ -285,7 +418,11 @@ export class IliCstParser extends CstParser {
 
   classModifier = this.RULE('classModifier', () => {
     this.CONSUME(LParen);
-    this.CONSUME(Abstract);
+    this.OR([
+      { ALT: () => this.CONSUME(Abstract) },
+      { ALT: () => this.CONSUME(Final) },
+      { ALT: () => this.CONSUME(Extended) },
+    ]);
     this.CONSUME(RParen);
   });
 
@@ -319,6 +456,10 @@ export class IliCstParser extends CstParser {
     this.CONSUME(Colon);
     this.OPTION2(() => this.CONSUME(Mandatory));
     this.SUBRULE(this.attributeType);
+    this.OPTION3(() => {
+      this.CONSUME(ColonEquals);
+      this.MANY(() => this.SUBRULE(this.geometryBodyToken));
+    });
     this.CONSUME(Semicolon);
   });
 
@@ -331,11 +472,24 @@ export class IliCstParser extends CstParser {
       { ALT: () => this.CONSUME(Boolean) },
       { ALT: () => this.CONSUME(Date) },
       { ALT: () => this.CONSUME(DateTime) },
+      { ALT: () => this.SUBRULE(this.referenceType) },
+      { ALT: () => this.SUBRULE(this.oidDomainType) },
       { ALT: () => this.SUBRULE(this.collectionType) },
       { ALT: () => this.SUBRULE(this.geometryType) },
       { ALT: () => this.SUBRULE(this.enumValueList) },
       { ALT: () => this.SUBRULE(this.qualifiedName) },
     ]);
+  });
+
+  referenceType = this.RULE('referenceType', () => {
+    this.CONSUME(Reference);
+    this.CONSUME(To);
+    this.OPTION(() => {
+      this.CONSUME(LParen);
+      this.CONSUME(External);
+      this.CONSUME(RParen);
+    });
+    this.SUBRULE(this.qualifiedName);
   });
 
   mtextType = this.RULE('mtextType', () => {
@@ -364,7 +518,30 @@ export class IliCstParser extends CstParser {
     this.OR([
       { ALT: () => this.CONSUME(NumberLiteral) },
       { ALT: () => this.CONSUME(Identifier) },
+      { ALT: () => this.CONSUME(HashIdentifier) },
       { ALT: () => this.CONSUME(StringLiteral) },
+      { ALT: () => this.CONSUME(Interlis) },
+      { ALT: () => this.CONSUME(Not) },
+      { ALT: () => this.CONSUME(And) },
+      { ALT: () => this.CONSUME(Or) },
+      { ALT: () => this.CONSUME(True) },
+      { ALT: () => this.CONSUME(False) },
+      { ALT: () => this.CONSUME(Null) },
+      { ALT: () => this.CONSUME(NotEqual) },
+      { ALT: () => this.CONSUME(EqualEqual) },
+      { ALT: () => this.CONSUME(ColonEquals) },
+      { ALT: () => this.CONSUME(At2) },
+      { ALT: () => this.CONSUME(Constraint) },
+      { ALT: () => this.CONSUME(Unique) },
+      { ALT: () => this.CONSUME(Existence) },
+      { ALT: () => this.CONSUME(Set) },
+      { ALT: () => this.CONSUME(Tid) },
+      { ALT: () => this.CONSUME(Oid) },
+      { ALT: () => this.CONSUME(Type) },
+      { ALT: () => this.CONSUME(All) },
+      { ALT: () => this.CONSUME(Reference) },
+      { ALT: () => this.CONSUME(Bag) },
+      { ALT: () => this.CONSUME(List) },
       { ALT: () => this.CONSUME(Comma) },
       { ALT: () => this.CONSUME(Dot) },
       { ALT: () => this.CONSUME(DotDot) },
@@ -395,6 +572,8 @@ export class IliCstParser extends CstParser {
       { ALT: () => this.CONSUME(Mandatory) },
       { ALT: () => this.CONSUME(Equals) },
       { ALT: () => this.CONSUME(Colon) },
+      { ALT: () => this.CONSUME(Required) },
+      { ALT: () => this.CONSUME(In) },
     ]);
   });
 

--- a/src/features/ili-explorer/services/parsers/ng/tokens.ts
+++ b/src/features/ili-explorer/services/parsers/ng/tokens.ts
@@ -9,18 +9,23 @@ export const Whitespace = createToken({
 export const LineComment = createToken({
   name: 'LineComment',
   pattern: /!![^\n]*/,
-  group: Lexer.SKIPPED,
+  group: 'comments',
 });
 
 export const BlockComment = createToken({
   name: 'BlockComment',
   pattern: /\/\*[\s\S]*?\*\//,
-  group: Lexer.SKIPPED,
+  group: 'comments',
 });
 
 export const Identifier = createToken({
   name: 'Identifier',
   pattern: /[a-zA-ZäöüÄÖÜß][a-zA-Z0-9äöüÄÖÜß_]*/,
+});
+
+export const HashIdentifier = createToken({
+  name: 'HashIdentifier',
+  pattern: /#[a-zA-ZäöüÄÖÜß][a-zA-Z0-9äöüÄÖÜß_.]*/,
 });
 
 function kw(name: string, literal?: string): TokenType {
@@ -102,6 +107,13 @@ export const External = kw('External', 'EXTERNAL');
 export const Restriction = kw('Restriction', 'RESTRICTION');
 export const Attribute = kw('Attribute', 'ATTRIBUTE');
 export const Unqualified = kw('Unqualified', 'UNQUALIFIED');
+export const Basket = kw('Basket', 'BASKET');
+export const Depends = kw('Depends', 'DEPENDS');
+export const On = kw('On', 'ON');
+export const No = kw('No', 'NO');
+export const Format = kw('Format', 'FORMAT');
+export const In = kw('In', 'IN');
+export const Constraints = kw('Constraints', 'CONSTRAINTS');
 
 export const StringLiteral = createToken({
   name: 'StringLiteral',
@@ -152,14 +164,15 @@ export const allTokens: TokenType[] = [
   Interlis, Version, Model, Topic, Class, Structure, Association, Enumeration,
   Domain, Unit, Function, View, Graphic, Refsystem, Coordsystem, Imports,
   End, Extends, Extended, Abstract, Final, Mandatory, All, Of, Bag, List,
-  Reference, Base, Constraint, Existence, Unique, Set, Where, Required,
+  Reference, Base, Constraints, Constraint, Existence, Unique, Set, Where, Required,
   Numeric, Text, MText, Boolean, DateTime, Date,
   Coord, MultiCoord, Polyline, MultiPolyline, Surface, MultiSurface, Area, MultiArea,
   AnyClass, AnyStructure, Translation, Attribute, At, Or, And, Not, Null, True, False,
   Inherit, To, From, Without, With, Oid, Tid, As, Type, External, Restriction,
-  Unqualified,
+  Unqualified, Basket, Depends, On, No, Format, In,
 
   Identifier,
+  HashIdentifier,
 
   StringLiteral,
   NumberLiteral,


### PR DESCRIPTION
… 2.3/2.4 schemas

Universal hardening pass: the NG parser was previously targeted at one schema family and failed on common constructs in others. This commit extends grammar and visitor to handle the construct set found across a mixed corpus of public Swiss GIS / INTERLIS-meta schemas.