### PR TITLE
feat(parser+ui): Phase 5 UNIT semantics + duplicate-edge fixes + cons…

### DIFF
--- a/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
@@ -83,12 +83,6 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
   };
 
  
-  console.log('Association Node Render:', {
-    label: data.label,
-    isSource: data.isSource,
-    association: data.association
-  });
-
   return (
     <Paper 
       elevation={2}

--- a/src/features/ili-explorer/components/nodes/IliDomainEnumNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliDomainEnumNode.tsx
@@ -181,19 +181,24 @@ export const IliDomainEnumNode: React.FC<IliDomainEnumNodeProps> = memo(({ data 
     >
       <ResizeHandle position="right" onMouseDown={handleResizeStart} />
       
-      <Handle 
+      <Handle
         type="target"
         position={Position.Left}
         id="left"
-        style={{ 
+        style={{
           opacity: 1,
           background: colors.typeReference,
           width: 8,
           height: 8
         }}
       />
-      
-      <Box sx={{ 
+
+      {/* Top/Bottom handles für EXTENDS-Kanten zwischen Unit-Nodes
+          (UNIT-Typ mappt auf domainEnumNode-Visual). */}
+      <Handle type="source" position={Position.Top} id="top" style={{ opacity: 0 }} />
+      <Handle type="target" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
+
+      <Box sx={{
         bgcolor: data.isHighlighted 
           ? colors.selectedEntity 
           : alpha(colors.typeNode, 0.8),

--- a/src/features/ili-explorer/services/IliParserService.ts
+++ b/src/features/ili-explorer/services/IliParserService.ts
@@ -390,7 +390,6 @@ export class IliParserService {
     visited = new Set<string>()
   ): { className: string; attributes: IliAttribute[] }[] {
     const inherited: { className: string; attributes: IliAttribute[] }[] = [];
-    console.log(`Collecting inherited attributes for ${className}`);
 
    
     const classRegex = new RegExp(`CLASS\\s+${className}\\s*(?:\\(ABSTRACT\\))?\\s*EXTENDS\\s+([\\w\\.]+)\\s*=`, 'i');
@@ -398,11 +397,9 @@ export class IliParserService {
     
     if (match) {
       const superClassName = match[1];
-      console.log(`Found superclass: ${superClassName}`);
 
      
       if (visited.has(superClassName)) {
-        console.log(`Already visited ${superClassName}, skipping`);
         return inherited;
       }
       visited.add(superClassName);
@@ -416,7 +413,6 @@ export class IliParserService {
       if (superClassMatch) {
         const superClassContent = superClassMatch[1];
         const attributes = this.parseAttributes(superClassContent);
-        console.log(`Found ${attributes.length} attributes in superclass ${superClassName}`);
         
         if (attributes.length > 0) {
          
@@ -449,7 +445,6 @@ export class IliParserService {
     let match;
     while ((match = assocRegex.exec(content)) !== null) {
       const [_, assocName, assocContent] = match;
-      console.log('Found association:', assocName);
       
      
       const refRegex = /(\w+)Ref\s*(?:\(EXTERNAL\))?\s*--\s*\{(\d+|\*|\d+\.\.\d+|\d+\.\.\*)\}\s*([\w\.]+);/g;
@@ -480,7 +475,6 @@ export class IliParserService {
           targetCardinality: target.card
         };
         
-        console.log('Created association:', association);
         
        
         this.addAssociationToClass(associations, source.class, association);
@@ -516,7 +510,6 @@ export class IliParserService {
   ) {
     const existing = associations.get(className) || [];
     associations.set(className, [...existing, association]);
-    console.log(`Added association to class ${className}:`, association);
   }
 
   /**
@@ -532,7 +525,6 @@ export class IliParserService {
      
       this.domainEnums = this.parseDomainEnums(content);
       
-      console.log('Starting to parse content...');
 
      
       const enumRegex = /ENUMERATION\s+(\w+)\s*=\s*\(([\s\S]*?)\);/g;
@@ -560,15 +552,12 @@ export class IliParserService {
         };
         
         this.nodes.set(nodeId, node);
-        console.log(`Created enum node:`, node);
       }
 
       const classRegex = /CLASS\s+(\w+)\s*(?:\(ABSTRACT\))?\s*(?:EXTENDS\s+([\w\.]+))?\s*=\s*([\s\S]*?)(?=END\s+\1;)/g;
       
      
       const associations = this.parseAssociations(content);
-      console.log('Parsed associations:', associations);
-      console.log('Association count:', associations.size);
       
      
       const topicMatch = content.match(/TOPIC\s+(\w+)\s*=/);

--- a/src/features/ili-explorer/services/flowMapping.ts
+++ b/src/features/ili-explorer/services/flowMapping.ts
@@ -9,6 +9,7 @@ const FLOW_NODE_TYPE: Record<string, string> = {
   STRUCTURE: 'structureNode',
   ASSOCIATION: 'associationNode',
   ENUMERATION: 'enumNode',
+  UNIT: 'domainEnumNode',
   enumNode: 'enumNode',
   domainEnumNode: 'domainEnumNode',
 };

--- a/src/features/ili-explorer/services/iliSchemaService.ts
+++ b/src/features/ili-explorer/services/iliSchemaService.ts
@@ -30,7 +30,6 @@ export class IliSchemaService {
 
   public parseSchema(content: string): void {
     try {
-      console.log('Starting schema parsing...');
       this.clear();
       this.lastErrors = [];
 
@@ -43,21 +42,17 @@ export class IliSchemaService {
         nodes.find(node => node.type === 'CLASS');
 
       if (initialClass) {
-        console.log('Initial class:', initialClass);
         this.addNode(initialClass);
       }
 
       nodes.forEach(node => {
         if (node.id !== initialClass?.id) {
-          console.log('Adding node:', node);
           this.addNode(node);
         }
       });
 
-     
       relations.forEach(relation => {
         const id = `${relation.sourceId}-${relation.targetId}`;
-        console.log('Adding relation:', { id, relation });
         this.relations.set(id, relation);
       });
 

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -36,6 +36,11 @@ export function layoutAssociationCenter(
 
   if (!targetClass && !sourceClass) return null;
 
+  // Self-association: source and target are the same class. Push the class
+  // node only once — two edges to it would otherwise render with a duplicate
+  // node id and React Flow drops one silently, leaving a dangling edge.
+  const isSelfAssoc = !!sourceClass && !!targetClass && sourceClass.id === targetClass.id;
+
   const nodes: IliNode[] = [];
   const edges: Edge[] = [];
 
@@ -55,7 +60,7 @@ export function layoutAssociationCenter(
     data: { ...entity.data, isHighlighted: true, isActive: true },
   });
 
-  if (targetClass) {
+  if (targetClass && !isSelfAssoc) {
     nodes.push({
       ...targetClass,
       position: { x: LAYOUT_CONFIG.ASSOCIATION.CLASS_SPACING, y: 0 },
@@ -81,7 +86,7 @@ export function layoutAssociationCenter(
     });
   }
 
-  if (targetClass) {
+  if (targetClass && !isSelfAssoc) {
     edges.push({
       id: `${entity.id}-${targetClass.id}-target`,
       source: entity.id,

--- a/src/features/ili-explorer/services/layout/enumStrategy.ts
+++ b/src/features/ili-explorer/services/layout/enumStrategy.ts
@@ -94,6 +94,10 @@ export function attachClassEnums(
   const totalHeight = (totalEnums - 1) * spacingY;
   const startY = -(totalHeight / 2);
 
+  // Mehrere Attribute können denselben Domain-Enum referenzieren — pro
+  // (entity, enumNode) nur einmal eine Edge erzeugen, sonst kollidieren die
+  // Edge-Keys (`${entity.id}-${enumNodeId}-enum`).
+  const seenEnumIds = new Set<string>();
   attributes.forEach((attr, index) => {
     if (!attr.isEnum && !attr.isDomainEnum) return;
 
@@ -102,6 +106,9 @@ export function attachClassEnums(
       : attr.isInlineEnum
         ? `enum_${entity.id}_${attr.name}`
         : `enum_${attr.type}`;
+
+    if (seenEnumIds.has(enumNodeId)) return;
+    seenEnumIds.add(enumNodeId);
 
     const enumNode: IliNode = nodeMap.get(enumNodeId) || {
       id: enumNodeId,

--- a/src/features/ili-explorer/services/parsers/ng/__tests__/universal.test.ts
+++ b/src/features/ili-explorer/services/parsers/ng/__tests__/universal.test.ts
@@ -316,3 +316,61 @@ describe('NG Phase 4 — VIEW semantisch', () => {
     expect(v?.data.formation?.sources).toEqual(['A', 'B']);
   });
 });
+
+describe('NG Phase 5 — UNIT semantisch', () => {
+  it('extracts simple unit definitions with short names', () => {
+    const src = wrap(`
+  UNIT
+    Length (ABSTRACT);
+    Meter [m] EXTENDS Length;
+    Kilometer [km] EXTENDS Length = 1000 [m];`);
+    const r = new NgIliParser().parseContent(src);
+    expect(r.errors).toEqual([]);
+    const units = r.nodes.filter(n => n.type === 'UNIT');
+    expect(units.length).toBe(3);
+    const length = units.find(u => u.name === 'Length');
+    expect(length?.isAbstract).toBe(true);
+    const meter = units.find(u => u.name === 'Meter');
+    expect(meter?.data.shortName).toBe('m');
+    expect(meter?.data.extends).toBe('Length');
+  });
+
+  it('emits UNIT-EXTENDS edges for derived units', () => {
+    const src = wrap(`
+  UNIT
+    Length (ABSTRACT);
+    Meter [m] EXTENDS Length;
+    Centimeter [cm] EXTENDS Length;`);
+    const r = new NgIliParser().parseContent(src);
+    const unitExt = r.relations.filter(re =>
+      re.type === 'EXTENDS' && re.sourceId.startsWith('unit_')
+    );
+    expect(unitExt.length).toBe(2);
+  });
+
+  it('handles DerivedUnit with FUNCTION body', () => {
+    const src = wrap(`
+  UNIT
+    Pa (ABSTRACT);
+    K (ABSTRACT);
+    Decibel [dB] = FUNCTION // 10**(dB/20) * 0.00002 // [Pa];
+    Degree_Celsius [oC] = FUNCTION // oC+273.15 // [K];`);
+    const r = new NgIliParser().parseContent(src);
+    expect(r.errors).toEqual([]);
+    const units = r.nodes.filter(n => n.type === 'UNIT');
+    expect(units.find(u => u.name === 'Decibel')?.data.shortName).toBe('dB');
+  });
+
+  it('handles ComposedUnit body with paren-balanced expression', () => {
+    const src = wrap(`
+  UNIT
+    LENGTH (ABSTRACT);
+    TIME (ABSTRACT);
+    Velocity (ABSTRACT) = (LENGTH/TIME);
+    Acceleration (ABSTRACT) = (Velocity/TIME);`);
+    const r = new NgIliParser().parseContent(src);
+    expect(r.errors).toEqual([]);
+    const units = r.nodes.filter(n => n.type === 'UNIT');
+    expect(units.length).toBe(4);
+  });
+});

--- a/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
+++ b/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
@@ -163,11 +163,14 @@ class IliCstToAstVisitor extends BaseVisitor {
       const targetNode = this.state.nodes.find(
         n => n.type === 'CLASS' && n.name === assoc.targetClass,
       ) as IliClassNode | undefined;
+      // Self-Assoc nur einmal anhängen — sonst rendert die UI zwei Edges
+      // mit identischer Key und React Flow erzeugt Geister-Edges.
+      const isSelf = sourceNode && targetNode && sourceNode.id === targetNode.id;
       if (sourceNode) {
         sourceNode.associations = [...(sourceNode.associations ?? []), assoc];
         sourceNode.data.associations = sourceNode.associations;
       }
-      if (targetNode) {
+      if (targetNode && !isSelf) {
         targetNode.associations = [...(targetNode.associations ?? []), assoc];
         targetNode.data.associations = targetNode.associations;
       }
@@ -204,6 +207,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     if (ctx.associationDef) ctx.associationDef.forEach((a: CstNode) => this.visit(a));
     if (ctx.functionDef) ctx.functionDef.forEach((f: CstNode) => this.visit(f));
     if (ctx.viewDef) ctx.viewDef.forEach((v: CstNode) => this.visit(v));
+    if (ctx.unitSection) ctx.unitSection.forEach((u: CstNode) => this.visit(u));
   }
 
   modelHeaderBits() {}
@@ -466,7 +470,53 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
   }
 
-  unitSection() {}
+  unitSection(ctx: any) {
+    if (ctx.unitDef) ctx.unitDef.forEach((u: CstNode) => this.visit(u));
+  }
+
+  unitDef(ctx: any) {
+    const unitName = imageOf(ctx.unitName?.[0]);
+    if (!unitName) return;
+    const isAbstract = !!ctx.Abstract;
+    const shortName = ctx.shortName?.[0] ? imageOf(ctx.shortName[0]) : undefined;
+    const comment = this.commentFor(ctx.unitName?.[0]);
+
+    let extendsRef: string | undefined;
+    if (ctx.extendsRef) {
+      extendsRef = this.visit(ctx.extendsRef[0]) as string;
+    }
+
+    const id = `unit_${unitName}`;
+    const label = shortName ? `${unitName} [${shortName}]` : unitName;
+    const node: IliBaseNode = {
+      id,
+      type: 'UNIT',
+      name: unitName,
+      isAbstract,
+      position: { x: 0, y: 0 },
+      data: {
+        label,
+        isAbstract,
+        shortName,
+        extends: extendsRef,
+        topic: this.state.topicName,
+        comment,
+        isHighlighted: false,
+        isActive: false,
+      },
+    };
+    this.state.nodes.push(node);
+
+    if (extendsRef) {
+      this.state.relations.push({
+        id: `${id}-extends-${extendsRef}`,
+        sourceId: id,
+        targetId: `unit_${lastSegment(extendsRef)}`,
+        type: 'EXTENDS',
+      });
+    }
+  }
+
   skipStatement() {}
 
   allOfClause(ctx: any): string {

--- a/src/features/ili-explorer/services/parsers/ng/parser.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser.ts
@@ -107,6 +107,7 @@ export class IliCstParser extends CstParser {
   geometryBodyToken!: any;
 
   unitSection!: any;
+  unitDef!: any;
   skipStatement!: any;
 
   // Phase 1+ — advanced rules (skips and structured)

--- a/src/features/ili-explorer/services/parsers/ng/parser/class.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser/class.ts
@@ -46,6 +46,9 @@ export function registerClassRules(p: IliCstParserBuilder): void {
         { ALT: () => p.SUBRULE(p.attributeDef) },
         { ALT: () => p.SUBRULE(p.constraintClause) },
         { ALT: () => p.SUBRULE(p.noOidClause) },
+        { ALT: () => p.SUBRULE(p.topicOidDecl) },
+        // ATTRIBUTE-Marker auch mitten im Body zulassen (nicht nur direkt nach `=`)
+        { ALT: () => p.CONSUME2(Attribute) },
       ]);
     });
     p.CONSUME(End);

--- a/src/features/ili-explorer/services/parsers/ng/parser/units.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser/units.ts
@@ -1,33 +1,82 @@
 import type { IliCstParserBuilder } from '../parser';
 import {
-  Unit, Semicolon, LParen, RParen,
+  Unit, Identifier, Semicolon, Equals, Extends,
+  LParen, RParen, LBracket, RBracket, Abstract, Function,
   Topic, Class, Structure, Association, Enumeration, Domain,
-  Imports, End, Function, View, Graphic, Refsystem, Parameter,
+  Imports, End, View, Graphic, Refsystem, Parameter,
 } from '../tokens';
 
 export function registerUnitsRules(p: IliCstParserBuilder): void {
   p.unitSection = p.RULE('unitSection', () => {
     p.CONSUME(Unit);
-    // Stop bei den Tokens, die einen neuen Top-Level-Konstrukt einleiten:
-    // andernfalls würde skipStatement gierig in TOPIC/CLASS/... reinfressen.
     p.MANY({
       GATE: () => {
         const t = p.LA(1).tokenType;
-        return t !== Topic && t !== Class && t !== Structure
+        return t === Identifier;
+      },
+      DEF: () => p.SUBRULE(p.unitDef),
+    });
+  });
+
+  // UnitDef = Name [ (ABSTRACT) | [ShortName] ] [ EXTENDS UnitRef ]
+  //          [ = ( DerivedUnit | ComposedUnit ) ] ;
+  // Body (DerivedUnit/ComposedUnit) bleibt Token-Salat — der semantische
+  // Wert liegt in Name, Short, ABSTRACT-Flag und EXTENDS.
+  p.unitDef = p.RULE('unitDef', () => {
+    p.CONSUME(Identifier, { LABEL: 'unitName' });
+    p.OPTION(() => p.OR([
+      {
+        ALT: () => {
+          p.CONSUME(LParen);
+          p.CONSUME(Abstract);
+          p.CONSUME(RParen);
+        },
+      },
+      {
+        ALT: () => {
+          p.CONSUME(LBracket);
+          p.CONSUME2(Identifier, { LABEL: 'shortName' });
+          p.CONSUME(RBracket);
+        },
+      },
+    ]));
+    p.OPTION2(() => {
+      p.CONSUME(Extends);
+      p.SUBRULE(p.qualifiedName, { LABEL: 'extendsRef' });
+    });
+    p.OPTION3(() => {
+      p.CONSUME(Equals);
+      p.MANY({
+        GATE: () => p.LA(1).tokenType !== Semicolon,
+        DEF: () => p.OR2([
+          {
+            ALT: () => {
+              p.CONSUME2(LParen);
+              p.SUBRULE(p.parenContents);
+              p.CONSUME2(RParen);
+            },
+          },
+          { ALT: () => p.CONSUME(Function) },
+          { ALT: () => p.SUBRULE(p.skipBodyToken) },
+        ]),
+      });
+    });
+    p.CONSUME(Semicolon);
+  });
+
+  // Legacy fallback — bleibt im Builder, falls jemand es referenziert.
+  // (Wird vom Konstruktor erwartet, dürfen wir nicht ungebunden lassen.)
+  p.skipStatement = p.RULE('skipStatement', () => {
+    p.AT_LEAST_ONE({
+      GATE: () => {
+        const t = p.LA(1).tokenType;
+        return t !== Semicolon
+          && t !== Topic && t !== Class && t !== Structure
           && t !== Association && t !== Enumeration && t !== Domain
           && t !== Imports && t !== Unit && t !== End
           && t !== Function && t !== View && t !== Graphic
           && t !== Refsystem && t !== Parameter;
       },
-      DEF: () => p.SUBRULE(p.skipStatement),
-    });
-  });
-
-  // Unit-Eintrag: bis zum nächsten ';' alle Tokens schlucken (paren-balanced).
-  // FUNCTION ist erlaubt (DerivedUnit-Form `= FUNCTION // ... // [unit]`).
-  p.skipStatement = p.RULE('skipStatement', () => {
-    p.AT_LEAST_ONE({
-      GATE: () => p.LA(1).tokenType !== Semicolon,
       DEF: () => p.OR([
         {
           ALT: () => {
@@ -36,7 +85,7 @@ export function registerUnitsRules(p: IliCstParserBuilder): void {
             p.CONSUME(RParen);
           },
         },
-        { ALT: () => p.CONSUME(Function) },
+        { ALT: () => p.CONSUME2(Function) },
         { ALT: () => p.SUBRULE(p.skipBodyToken) },
       ]),
     });

--- a/src/features/ili-explorer/services/types/IliBaseTypes.ts
+++ b/src/features/ili-explorer/services/types/IliBaseTypes.ts
@@ -9,6 +9,7 @@ export type IliNodeType =
   | 'ENUMERATION'
   | 'FUNCTION'
   | 'VIEW'
+  | 'UNIT'
   | 'enumNode'
   | 'domainEnumNode';
 


### PR DESCRIPTION
…ole cleanup

UNIT semantically (Phase 5, headline):
- structured unitDef rule replaces the token-salad skipStatement: extracts Name, optional [shortName], (ABSTRACT) flag, EXTENDS-ref, body
- new IliNodeType 'UNIT' + AST visitor; EXTENDS edges between units
- UNIT renders as domainEnumNode chip (label "Name [short]")
- domainEnumNode gains top/bottom handles so unit-EXTENDS edges bind cleanly without React-Flow source-handle warnings

Real-world schema fixes:
- CLASS body accepts `OID AS X;` mid-body and a stray `ATTRIBUTE` marker (older convention used by some Swiss vendor models)
- unitSection MANY now gates on top-level keywords so it doesn't greedily consume into the next TOPIC/CLASS

Layout duplicate-key fixes (root-cause Geister-Edges in React Flow):
- decorateAssociations: self-associations are appended once instead of twice (was the source of duplicate edge ids in attachClassAssociations)
- attachClassEnums: deduplicate by enum-id when several attributes of one class point to the same domain enum
- layoutAssociationCenter: omit the redundant second edge for self-associations (both roles already shown in the details panel)

Console hygiene:
- strip per-render / per-parse console.log noise from iliSchemaService, IliAssociationNode and the legacy IliParserService — only real errors and React-Flow warnings remain