### PR TITLE
feat(ui): model-info panel with imports & INTERLIS version

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -43,6 +43,7 @@ import {
 import { useIliSchema } from '../hooks/useIliSchema';
 import { useDiagramExport } from '../hooks/useDiagramExport';
 import { LayoutSettings } from './sidebar/LayoutSettings';
+import { ModelInfoPanel } from './sidebar/ModelInfoPanel';
 
 import '@xyflow/react/dist/style.css';
 import { debounce } from 'lodash';
@@ -111,6 +112,8 @@ const Flow: React.FC = () => {
     error,
     parseWarnings,
     dismissParseWarnings,
+    imports,
+    interlisVersion,
     searchValue,
     searchOptions,
     currentFileName,
@@ -486,11 +489,46 @@ const Flow: React.FC = () => {
     const styleSheet = document.createElement('style');
     styleSheet.innerText = globalStyles;
     document.head.appendChild(styleSheet);
-    
+
     return () => {
       document.head.removeChild(styleSheet);
     };
   }, []);
+
+  const modelStats = useMemo(() => {
+    let classCount = 0, topicCount = 0, associationCount = 0, enumCount = 0, unitCount = 0;
+    for (const n of allNodes) {
+      switch (n.type) {
+        case 'classNode': classCount++; break;
+        case 'topicNode': topicCount++; break;
+        case 'associationNode': associationCount++; break;
+        case 'enumNode': enumCount++; break;
+        case 'domainEnumNode':
+          if ((n.data as any)?.type === 'UNIT') unitCount++;
+          else enumCount++;
+          break;
+      }
+    }
+    return { classCount, topicCount, associationCount, enumCount, unitCount };
+  }, [allNodes]);
+
+  const lastLoadedFileRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (isLoading || error) return;
+    if (!currentFileName || currentFileName === lastLoadedFileRef.current) return;
+    if (allNodes.length === 0) return;
+    lastLoadedFileRef.current = currentFileName;
+    const classCount = allNodes.filter(n => n.type === 'classNode').length;
+    const warnCount = parseWarnings.length;
+    const summary = warnCount > 0
+      ? `${currentFileName} geladen — ${classCount} Klassen, ${warnCount} ${warnCount === 1 ? 'Warnung' : 'Warnungen'}`
+      : `${currentFileName} geladen — ${classCount} Klassen`;
+    showToast(summary, warnCount > 0 ? 'warning' : 'success');
+  }, [isLoading, error, currentFileName, allNodes, parseWarnings, showToast]);
+
+  useEffect(() => {
+    if (!currentFileName) lastLoadedFileRef.current = null;
+  }, [currentFileName]);
 
   return (
     <Box
@@ -517,13 +555,13 @@ const Flow: React.FC = () => {
       )}
 
       {error && (
-        <Box sx={{ position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)', zIndex: 1000 }}>
+        <Box sx={{ position: 'absolute', top: 80, left: '50%', transform: 'translateX(-50%)', zIndex: 1000 }}>
           <Alert severity="error">{error}</Alert>
         </Box>
       )}
 
       {parseWarnings.length > 0 && (
-        <Box sx={{ position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)', zIndex: 1000, maxWidth: '80%' }}>
+        <Box sx={{ position: 'absolute', top: 80, left: '50%', transform: 'translateX(-50%)', zIndex: 1000, maxWidth: '80%' }}>
           <Alert
             severity="warning"
             onClose={dismissParseWarnings}
@@ -600,6 +638,17 @@ const Flow: React.FC = () => {
         </Panel>
 
         <Panel position="top-left" style={{ marginTop: 68, marginLeft: 16 }}>
+          <ModelInfoPanel
+            fileName={currentFileName}
+            classCount={modelStats.classCount}
+            topicCount={modelStats.topicCount}
+            associationCount={modelStats.associationCount}
+            enumCount={modelStats.enumCount}
+            unitCount={modelStats.unitCount}
+            imports={imports}
+            warningCount={parseWarnings.length}
+            interlisVersion={interlisVersion}
+          />
           <LayoutSettings
             maxSubTypesPerRow={maxSubTypesPerRow}
             onMaxSubTypesChange={debouncedHandleMaxSubTypesChange}

--- a/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
+++ b/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from 'react';
+import {
+  IconButton,
+  Popover,
+  Box,
+  Typography,
+  Paper,
+  Tooltip,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Chip,
+  Collapse,
+  Link,
+} from '@mui/material';
+import {
+  InfoOutlined,
+  DownloadOutlined,
+  ExpandMore,
+  ExpandLess,
+} from '@mui/icons-material';
+import { useTheme } from '../../../../common/theme/ThemeContext';
+import type { IliImportRef } from '../../services/parsers/IliParser';
+
+interface ModelInfoPanelProps {
+  fileName: string | null;
+  classCount: number;
+  topicCount: number;
+  associationCount: number;
+  enumCount: number;
+  unitCount: number;
+  imports: IliImportRef[];
+  warningCount: number;
+  interlisVersion: string | undefined;
+}
+
+const STD_LIBS = new Set(['INTERLIS', 'Units', 'Time', 'CoordSys']);
+
+export const ModelInfoPanel: React.FC<ModelInfoPanelProps> = ({
+  fileName,
+  classCount,
+  topicCount,
+  associationCount,
+  enumCount,
+  unitCount,
+  imports,
+  warningCount,
+  interlisVersion,
+}) => {
+  const { colors } = useTheme();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [stdOpen, setStdOpen] = useState(false);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+
+  const open = Boolean(anchorEl);
+  const hasModel = !!fileName;
+
+  const realImports = imports.filter(i => !STD_LIBS.has(i.name));
+  const stdImports = imports.filter(i => STD_LIBS.has(i.name));
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        p: 0.5,
+        bgcolor: 'background.paper',
+        borderRadius: 1,
+        mb: 1,
+      }}
+    >
+      <Tooltip title={hasModel ? 'Modell-Info & Imports' : 'Kein Modell geladen'}>
+        <span>
+          <IconButton onClick={handleClick} size="small" disabled={!hasModel}>
+            <InfoOutlined fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      >
+        <Box sx={{ p: 2, width: 380, maxHeight: 520, overflowY: 'auto' }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Modell-Info
+          </Typography>
+
+          {fileName && (
+            <Typography
+              variant="body2"
+              sx={{ fontFamily: 'monospace', wordBreak: 'break-all', mb: 1 }}
+            >
+              {fileName}
+            </Typography>
+          )}
+
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1.5 }}>
+            {interlisVersion && (
+              <Chip size="small" color="primary" label={`INTERLIS ${interlisVersion}`} />
+            )}
+            <Chip size="small" label={`${classCount} Klassen`} />
+            {topicCount > 0 && <Chip size="small" label={`${topicCount} Topics`} />}
+            {associationCount > 0 && <Chip size="small" label={`${associationCount} Assoc.`} />}
+            {enumCount > 0 && <Chip size="small" label={`${enumCount} Enums`} />}
+            {unitCount > 0 && <Chip size="small" label={`${unitCount} Units`} />}
+            {warningCount > 0 && (
+              <Chip
+                size="small"
+                color="warning"
+                label={`${warningCount} ${warningCount === 1 ? 'Warnung' : 'Warnungen'}`}
+              />
+            )}
+          </Box>
+
+          <Divider sx={{ my: 1.5 }} />
+
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Imports {realImports.length > 0 && `(${realImports.length})`}
+          </Typography>
+
+          {realImports.length === 0 ? (
+            <Typography variant="caption" sx={{ color: colors.text, opacity: 0.6 }}>
+              Keine externen Modell-Abhängigkeiten.
+            </Typography>
+          ) : (
+            <List dense disablePadding>
+              {realImports.map(imp => (
+                <ListItem
+                  key={imp.name}
+                  disableGutters
+                  sx={{ py: 0.25 }}
+                  secondaryAction={
+                    <Tooltip title="Modell laden (in Vorbereitung)">
+                      <span>
+                        <IconButton size="small" disabled aria-label={`Import ${imp.name} laden`}>
+                          <DownloadOutlined fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  }
+                >
+                  <ListItemText
+                    disableTypography
+                    primary={
+                      <Typography
+                        variant="body2"
+                        component="div"
+                        sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+                      >
+                        {imp.name}
+                      </Typography>
+                    }
+                    secondary={
+                      imp.unqualified ? (
+                        <Box sx={{ display: 'flex', gap: 0.5, mt: 0.25 }}>
+                          <Chip
+                            size="small"
+                            label="UNQUALIFIED"
+                            sx={{ height: 18, fontSize: '0.65rem' }}
+                          />
+                        </Box>
+                      ) : null
+                    }
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+
+          {stdImports.length > 0 && (
+            <Box sx={{ mt: 1 }}>
+              <Link
+                component="button"
+                type="button"
+                underline="hover"
+                onClick={() => setStdOpen(o => !o)}
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  fontSize: '0.75rem',
+                  color: colors.text,
+                  opacity: 0.7,
+                  background: 'none',
+                  border: 0,
+                  cursor: 'pointer',
+                  p: 0,
+                }}
+              >
+                {stdOpen ? <ExpandLess fontSize="inherit" /> : <ExpandMore fontSize="inherit" />}
+                {stdImports.length} Standard-{stdImports.length === 1 ? 'Library' : 'Libraries'}
+              </Link>
+              <Collapse in={stdOpen} timeout="auto" unmountOnExit>
+                <Box sx={{ mt: 0.5, pl: 2, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                  {stdImports.map(imp => (
+                    <Typography
+                      key={imp.name}
+                      variant="caption"
+                      sx={{
+                        fontFamily: 'monospace',
+                        color: colors.text,
+                        opacity: 0.7,
+                      }}
+                    >
+                      {imp.name}
+                      {imp.unqualified && (
+                        <span style={{ opacity: 0.5, marginLeft: 6 }}>(unqualified)</span>
+                      )}
+                    </Typography>
+                  ))}
+                </Box>
+              </Collapse>
+            </Box>
+          )}
+
+          <Divider sx={{ my: 1.5 }} />
+          <Typography variant="caption" sx={{ color: colors.text, opacity: 0.6 }}>
+            Imports laden ist in Vorbereitung — die Liste zeigt aktuell nur die
+            im Modell deklarierten Abhängigkeiten.
+          </Typography>
+        </Box>
+      </Popover>
+    </Paper>
+  );
+};

--- a/src/features/ili-explorer/hooks/useDiagramExport.ts
+++ b/src/features/ili-explorer/hooks/useDiagramExport.ts
@@ -83,9 +83,9 @@ export function useDiagramExport(currentFileName: string | null) {
 
   const [toastOpen, setToastOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
-  const [toastSeverity, setToastSeverity] = useState<'success' | 'error'>('success');
+  const [toastSeverity, setToastSeverity] = useState<'success' | 'info' | 'warning' | 'error'>('success');
 
-  const showToast = useCallback((message: string, severity: 'success' | 'error') => {
+  const showToast = useCallback((message: string, severity: 'success' | 'info' | 'warning' | 'error') => {
     setToastMessage(message);
     setToastSeverity(severity);
     setToastOpen(true);

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -22,7 +22,7 @@ import {
   LayoutOptions,
 } from '../services/types/IliBaseTypes';
 import { IliClassNode } from '../services/types/IliModelTypes';
-import type { IliParseError } from '../services/parsers/IliParser';
+import type { IliParseError, IliImportRef } from '../services/parsers/IliParser';
 
 export type { SearchOption };
 
@@ -32,6 +32,8 @@ interface UseIliSchemaReturn {
   error: string | null;
   parseWarnings: IliParseError[];
   dismissParseWarnings: () => void;
+  imports: IliImportRef[];
+  interlisVersion: string | undefined;
   searchValue: SearchOption | null;
   searchOptions: SearchOption[];
   currentFileName: string | null;
@@ -95,6 +97,8 @@ export const useIliSchema = (
   const [error, setError] = useState<string | null>(null);
   const [parseWarnings, setParseWarnings] = useState<IliParseError[]>([]);
   const dismissParseWarnings = useCallback(() => setParseWarnings([]), []);
+  const [imports, setImports] = useState<IliImportRef[]>([]);
+  const [interlisVersion, setInterlisVersion] = useState<string | undefined>(undefined);
   const [searchValue, setSearchValue] = useState<SearchOption | null>(null);
   const [searchOptions, setSearchOptions] = useState<SearchOption[]>([]);
   const [currentFileName, setCurrentFileName] = useState<string | null>(null);
@@ -193,6 +197,8 @@ export const useIliSchema = (
       lastContentRef.current = { content, fileName };
       schemaServiceRef.current.parseSchema(content);
       setParseWarnings(schemaServiceRef.current.getParseErrors());
+      setImports(schemaServiceRef.current.getImports());
+      setInterlisVersion(schemaServiceRef.current.getInterlisVersion());
 
       const baseNodes = schemaServiceRef.current.getNodes();
       const relations = schemaServiceRef.current.getRelations();
@@ -458,6 +464,9 @@ export const useIliSchema = (
     setSearchValue(null);
     setCurrentFileName(null);
     setError(null);
+    setParseWarnings([]);
+    setImports([]);
+    setInterlisVersion(undefined);
     setNavigationHistory([]);
     setHistoryIndex(-1);
     setActiveNodeId(null);
@@ -675,6 +684,8 @@ export const useIliSchema = (
     isLoading,
     error,
     parseWarnings,
+    imports,
+    interlisVersion,
     dismissParseWarnings,
     searchValue,
     searchOptions,

--- a/src/features/ili-explorer/services/iliSchemaService.ts
+++ b/src/features/ili-explorer/services/iliSchemaService.ts
@@ -8,7 +8,7 @@ import {
   IliTopicNode,
   IliClassNode
 } from './types/IliModelTypes';
-import type { IliParser, IliParseError } from './parsers/IliParser';
+import type { IliParser, IliParseError, IliImportRef } from './parsers/IliParser';
 import { LegacyIliParser } from './parsers/LegacyIliParser';
 import { v4 as uuid } from 'uuid';
 
@@ -17,6 +17,8 @@ export class IliSchemaService {
   private relations: Map<string, IliRelation>;
   private parser: IliParser;
   private lastErrors: IliParseError[] = [];
+  private lastImports: IliImportRef[] = [];
+  private lastInterlisVersion: string | undefined;
 
   constructor(parser: IliParser = new LegacyIliParser()) {
     this.nodes = new Map();
@@ -28,13 +30,25 @@ export class IliSchemaService {
     return this.lastErrors;
   }
 
+  public getImports(): IliImportRef[] {
+    return this.lastImports;
+  }
+
+  public getInterlisVersion(): string | undefined {
+    return this.lastInterlisVersion;
+  }
+
   public parseSchema(content: string): void {
     try {
       this.clear();
       this.lastErrors = [];
+      this.lastImports = [];
+      this.lastInterlisVersion = undefined;
 
-      const { nodes, relations, errors } = this.parser.parseContent(content);
+      const { nodes, relations, errors, imports, interlisVersion } = this.parser.parseContent(content);
       this.lastErrors = errors ?? [];
+      this.lastImports = imports ?? [];
+      this.lastInterlisVersion = interlisVersion;
       
      
       const initialClass =

--- a/src/features/ili-explorer/services/parsers/IliParser.ts
+++ b/src/features/ili-explorer/services/parsers/IliParser.ts
@@ -7,10 +7,17 @@ export interface IliParseError {
   column?: number;
 }
 
+export interface IliImportRef {
+  name: string;
+  unqualified?: boolean;
+}
+
 export interface IliParseResult {
   nodes: IliBaseNode[];
   relations: IliRelation[];
   errors?: IliParseError[];
+  imports?: IliImportRef[];
+  interlisVersion?: string;
 }
 
 export interface IliParser {

--- a/src/features/ili-explorer/services/parsers/ng/NgIliParser.ts
+++ b/src/features/ili-explorer/services/parsers/ng/NgIliParser.ts
@@ -56,6 +56,8 @@ export class NgIliParser implements IliParser {
       nodes: ast.nodes,
       relations: ast.relations,
       errors,
+      imports: ast.imports,
+      interlisVersion: ast.interlisVersion,
     };
   }
 }

--- a/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
+++ b/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
@@ -3,6 +3,7 @@ import type {
   IliBaseNode, IliRelation, IliAttribute, IliEnumValue, IliAssociation,
 } from '../../types/IliBaseTypes';
 import type { IliClassNode, IliStructureNode } from '../../types/IliModelTypes';
+import type { IliImportRef } from '../IliParser';
 import { cstParserInstance } from './parser';
 
 const BaseVisitor = cstParserInstance.getBaseCstVisitorConstructorWithDefaults();
@@ -11,6 +12,8 @@ interface VisitState {
   topicName: string;
   nodes: IliBaseNode[];
   relations: IliRelation[];
+  imports: IliImportRef[];
+  interlisVersion: string | undefined;
   domainEnumsByName: Map<string, IliEnumValue[]>;
   parsedAssociations: IliAssociation[];
   pendingReferences: { sourceClass: string; targetQualified: string; attrName: string; isExternal: boolean }[];
@@ -22,6 +25,24 @@ function lastSegment(qualified: string): string {
 
 function imageOf(token: IToken | undefined): string {
   return token ? token.image : '';
+}
+
+function firstTokenOf(node: CstNode): IToken | undefined {
+  let earliest: IToken | undefined;
+  const walk = (n: CstNode) => {
+    for (const key of Object.keys(n.children)) {
+      for (const child of n.children[key]) {
+        if ((child as IToken).image !== undefined) {
+          const tok = child as IToken;
+          if (!earliest || tok.startOffset < earliest.startOffset) earliest = tok;
+        } else {
+          walk(child as CstNode);
+        }
+      }
+    }
+  };
+  walk(node);
+  return earliest;
 }
 
 function extractCommentText(token: IToken): string | null {
@@ -43,7 +64,7 @@ function extractCommentText(token: IToken): string | null {
 
 class IliCstToAstVisitor extends BaseVisitor {
   private state: VisitState = {
-    topicName: '', nodes: [], relations: [],
+    topicName: '', nodes: [], relations: [], imports: [], interlisVersion: undefined,
     domainEnumsByName: new Map(), parsedAssociations: [],
     pendingReferences: [],
   };
@@ -57,9 +78,9 @@ class IliCstToAstVisitor extends BaseVisitor {
   build(
     cst: CstNode,
     commentBefore: Map<number, IToken[]> = new Map(),
-  ): { nodes: IliBaseNode[]; relations: IliRelation[] } {
+  ): { nodes: IliBaseNode[]; relations: IliRelation[]; imports: IliImportRef[]; interlisVersion: string | undefined } {
     this.state = {
-      topicName: '', nodes: [], relations: [],
+      topicName: '', nodes: [], relations: [], imports: [],
       domainEnumsByName: new Map(), parsedAssociations: [],
       pendingReferences: [],
     };
@@ -70,7 +91,12 @@ class IliCstToAstVisitor extends BaseVisitor {
     this.decorateReferences();
     this.decorateInheritedAttributes();
     this.decorateExternalNodes();
-    return { nodes: this.state.nodes, relations: this.state.relations };
+    return {
+      nodes: this.state.nodes,
+      relations: this.state.relations,
+      imports: this.state.imports,
+      interlisVersion: this.state.interlisVersion,
+    };
   }
 
   private decorateExternalNodes(): void {
@@ -195,10 +221,12 @@ class IliCstToAstVisitor extends BaseVisitor {
   }
 
   iliFile(ctx: any) {
+    if (ctx.interlisVersionDecl) ctx.interlisVersionDecl.forEach((v: CstNode) => this.visit(v));
     if (ctx.modelDef) ctx.modelDef.forEach((m: CstNode) => this.visit(m));
   }
 
   modelDef(ctx: any) {
+    if (ctx.importsClause) ctx.importsClause.forEach((i: CstNode) => this.visit(i));
     if (ctx.domainSection) ctx.domainSection.forEach((d: CstNode) => this.visit(d));
     if (ctx.topicDef) ctx.topicDef.forEach((t: CstNode) => this.visit(t));
     if (ctx.classDef) ctx.classDef.forEach((c: CstNode) => this.visit(c));
@@ -213,7 +241,27 @@ class IliCstToAstVisitor extends BaseVisitor {
   modelHeaderBits() {}
   languageTag() {}
   versionClause() {}
-  interlisVersionDecl() {}
+  interlisVersionDecl(ctx: any) {
+    const numTok = ctx.NumberLiteral?.[0] as IToken | undefined;
+    if (numTok) this.state.interlisVersion = numTok.image;
+  }
+
+  importsClause(ctx: any) {
+    const names = (ctx.qualifiedName as CstNode[] | undefined) ?? [];
+    const unqualifiedOffsets = new Set<number>(
+      ((ctx.Unqualified as IToken[] | undefined) ?? []).map(t => t.startOffset),
+    );
+    for (const nameNode of names) {
+      const name = this.visit(nameNode) as string;
+      if (!name) continue;
+      const firstTok = firstTokenOf(nameNode);
+      const unqualified = firstTok
+        ? [...unqualifiedOffsets].some(off => off < firstTok.startOffset && firstTok.startOffset - off < 64)
+        : false;
+      if (this.state.imports.some(im => im.name === name)) continue;
+      this.state.imports.push({ name, unqualified });
+    }
+  }
 
   topicDef(ctx: any) {
     const topicName = imageOf(ctx.topicName?.[0]);


### PR DESCRIPTION
NG parser extracts IMPORTS clauses (with UNQUALIFIED flag) and the INTERLIS version number, exposed via IliParseResult. New ModelInfoPanel above LayoutSettings shows filename, stat chips (INTERLIS 2.x, classes/ topics/assoc./enums/units/warnings), and an imports list — real models with load icon (prepared), standard libs (INTERLIS/Units/Time/CoordSys) collapsed without icon.