### PR TITLE
fix(parser): add missing interlisVersion to build() state reset

### DIFF
--- a/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
+++ b/src/features/ili-explorer/services/parsers/ng/astBuilder.ts
@@ -80,7 +80,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     commentBefore: Map<number, IToken[]> = new Map(),
   ): { nodes: IliBaseNode[]; relations: IliRelation[]; imports: IliImportRef[]; interlisVersion: string | undefined } {
     this.state = {
-      topicName: '', nodes: [], relations: [], imports: [],
+      topicName: '', nodes: [], relations: [], imports: [], interlisVersion: undefined,
       domainEnumsByName: new Map(), parsedAssociations: [],
       pendingReferences: [],
     };


### PR DESCRIPTION
The VisitState reset inside build() was missing the interlisVersion field, breaking `tsc -b` (Cloudflare build). Field-init was already correct, only the per-call reset was stale.