### PR TITLE
feat(ui): model overview as default landing view

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -38,7 +38,9 @@ import {
   IliEnumNode,
   IliAssociationNode,
   IliUnloadedClassNode,
-  IliDomainEnumNode
+  IliDomainEnumNode,
+  IliTopicLabelNode,
+  IliTopicFrameNode
 } from './nodes';
 import { useIliSchema } from '../hooks/useIliSchema';
 import { useDiagramExport } from '../hooks/useDiagramExport';
@@ -68,7 +70,9 @@ const nodeTypes: NodeTypes = {
   enumNode: IliEnumNode,
   domainEnumNode: IliDomainEnumNode,
   associationNode: IliAssociationNode,
-  unloadedClassNode: IliUnloadedClassNode
+  unloadedClassNode: IliUnloadedClassNode,
+  topicLabelNode: IliTopicLabelNode,
+  topicFrameNode: IliTopicFrameNode,
 };
 
 
@@ -126,6 +130,7 @@ const Flow: React.FC = () => {
     handleNodeClick: baseHandleNodeClick,
     handleReset: baseHandleReset,
     handleBack: baseHandleBack,
+    canGoBack,
     handleHierarchyToggle,
     activeNodeId,
     setActiveNodeId,
@@ -186,9 +191,10 @@ const Flow: React.FC = () => {
   const [nodePositionsHistory, setNodePositionsHistory] = useState<Map<string, { x: number; y: number }>[]>([]);
 
   const handleNodeClick = useCallback((event: React.MouseEvent, node: ReactFlowNode) => {
+    if (node.type === 'topicLabelNode' || node.type === 'topicFrameNode') return;
     if (node.id === activeNodeId) return;
-    
-   
+
+
     const nodeType = node.type || 'classNode';
     const nodeTitle = String(node.data?.label || node.data?.title || node.id);
     const isAbstract = Boolean(node.data?.isAbstract);
@@ -233,9 +239,9 @@ const Flow: React.FC = () => {
   }, [baseHandleReset, requestFitView, setMaxSubTypesPerRow]);
 
   const handleBack = useCallback(() => {
-    if (historyIndex > 0) {
-      baseHandleBack();
-
+    if (historyIndex < 0) return;
+    const went = baseHandleBack();
+    if (went && historyIndex > 0) {
       setNavigationHistory(prev => {
         const newHistory = [...prev];
         if (newHistory.length > 1) {
@@ -496,11 +502,13 @@ const Flow: React.FC = () => {
   }, []);
 
   const modelStats = useMemo(() => {
-    let classCount = 0, topicCount = 0, associationCount = 0, enumCount = 0, unitCount = 0;
+    let classCount = 0, associationCount = 0, enumCount = 0, unitCount = 0;
+    const topics = new Set<string>();
     for (const n of allNodes) {
+      const topic = (n.data as any)?.topic;
+      if (typeof topic === 'string' && topic.length > 0) topics.add(topic);
       switch (n.type) {
         case 'classNode': classCount++; break;
-        case 'topicNode': topicCount++; break;
         case 'associationNode': associationCount++; break;
         case 'enumNode': enumCount++; break;
         case 'domainEnumNode':
@@ -509,7 +517,7 @@ const Flow: React.FC = () => {
           break;
       }
     }
-    return { classCount, topicCount, associationCount, enumCount, unitCount };
+    return { classCount, topicCount: topics.size, associationCount, enumCount, unitCount };
   }, [allNodes]);
 
   const lastLoadedFileRef = useRef<string | null>(null);
@@ -657,6 +665,7 @@ const Flow: React.FC = () => {
             currentFileName={currentFileName}
             activeNodeId={activeNodeId}
             historyIndex={historyIndex}
+            canGoBack={canGoBack}
             showFullHierarchy={showFullHierarchy}
             useCurvedLines={useCurvedLines}
             exportAnchorEl={exportAnchorEl}

--- a/src/features/ili-explorer/components/nodes/IliTopicFrameNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliTopicFrameNode.tsx
@@ -1,0 +1,30 @@
+import React, { memo } from 'react';
+import { Box } from '@mui/material';
+import { useTheme } from '../../../../common/theme/ThemeContext';
+
+interface IliTopicFrameNodeProps {
+  data: {
+    width: number;
+    height: number;
+  };
+}
+
+export const IliTopicFrameNode: React.FC<IliTopicFrameNodeProps> = memo(({ data }) => {
+  const { colors } = useTheme();
+  return (
+    <Box
+      sx={{
+        width: data.width,
+        height: data.height,
+        border: `3px dashed ${colors.text}`,
+        opacity: 0.55,
+        borderRadius: 2,
+        pointerEvents: 'none',
+        userSelect: 'none',
+      }}
+    />
+  );
+});
+
+IliTopicFrameNode.displayName = 'IliTopicFrameNode';
+export default IliTopicFrameNode;

--- a/src/features/ili-explorer/components/nodes/IliTopicLabelNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliTopicLabelNode.tsx
@@ -1,0 +1,45 @@
+import React, { memo } from 'react';
+import { Box, Typography } from '@mui/material';
+import { useTheme } from '../../../../common/theme/ThemeContext';
+
+interface IliTopicLabelNodeProps {
+  data: {
+    label: string;
+    classCount: number;
+    isOrphanGroup?: boolean;
+  };
+}
+
+export const IliTopicLabelNode: React.FC<IliTopicLabelNodeProps> = memo(({ data }) => {
+  const { colors } = useTheme();
+  const accent = data.isOrphanGroup ? colors.text : colors.primary;
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 0.5,
+        borderLeft: `4px solid ${accent}`,
+        bgcolor: 'transparent',
+        color: colors.text,
+        userSelect: 'none',
+        pointerEvents: 'none',
+        opacity: data.isOrphanGroup ? 0.85 : 1,
+      }}
+    >
+      <Typography variant="overline" sx={{ display: 'block', lineHeight: 1, opacity: 0.7 }}>
+        {data.isOrphanGroup ? 'NO TOPIC' : 'TOPIC'}
+      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mt: 0.25 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+          {data.label}
+        </Typography>
+        <Typography variant="caption" sx={{ opacity: 0.55 }}>
+          {data.classCount} {data.classCount === 1 ? 'root class' : 'root classes'}
+        </Typography>
+      </Box>
+    </Box>
+  );
+});
+
+IliTopicLabelNode.displayName = 'IliTopicLabelNode';
+export default IliTopicLabelNode;

--- a/src/features/ili-explorer/components/nodes/index.ts
+++ b/src/features/ili-explorer/components/nodes/index.ts
@@ -6,3 +6,5 @@ export { IliEnumNode } from './IliEnumNode';
 export { IliDomainEnumNode } from './IliDomainEnumNode';
 export { IliAssociationNode } from './IliAssociationNode';
 export { IliUnloadedClassNode } from './IliUnloadedClassNode';
+export { IliTopicLabelNode } from './IliTopicLabelNode';
+export { IliTopicFrameNode } from './IliTopicFrameNode';

--- a/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
+++ b/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
@@ -24,6 +24,7 @@ interface IliSideToolbarProps {
   currentFileName: string | null;
   activeNodeId: string | null;
   historyIndex: number;
+  canGoBack?: boolean;
   showFullHierarchy: boolean;
   useCurvedLines: boolean;
   exportAnchorEl: HTMLElement | null;
@@ -45,6 +46,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
   currentFileName,
   activeNodeId,
   historyIndex,
+  canGoBack,
   showFullHierarchy,
   useCurvedLines,
   exportAnchorEl,
@@ -99,7 +101,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
 
       <Tooltip title="Zurück zur vorherigen Ansicht" placement="right">
         <span>
-          <IconButton size="small" onClick={onBack} disabled={historyIndex <= 0} aria-label="Go back">
+          <IconButton size="small" onClick={onBack} disabled={canGoBack === undefined ? historyIndex <= 0 : !canGoBack} aria-label="Go back">
             <ArrowBack fontSize="small" />
           </IconButton>
         </span>

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -8,6 +8,7 @@ import { IliSchemaService } from '../services/iliSchemaService';
 import { LegacyIliParser } from '../services/parsers/LegacyIliParser';
 import { NgIliParser } from '../services/parsers/ng/NgIliParser';
 import { IliLayoutService } from '../services/IliLayoutService';
+import { isOverviewCandidate, layoutModelOverview } from '../services/layout/overviewStrategy';
 import { generateSearchOptions } from '../services/searchOptions';
 import {
   flowNodeFromBaseNode,
@@ -68,6 +69,7 @@ interface UseIliSchemaReturn {
   computeLayout: (node: IliNode, override?: Partial<LayoutOptions>) => { nodes: IliNode[]; edges: Edge[] };
   fitViewRequest: number;
   requestFitView: () => void;
+  canGoBack: boolean;
 }
 
 
@@ -212,41 +214,51 @@ export const useIliSchema = (
       setSearchOptions(generateSearchOptions(baseNodes));
 
      
-      const initialClass = (
-        flowNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
-        flowNodes.find(n => n.type === 'classNode')
-      ) as IliNode | undefined;
+      const showOverview = isOverviewCandidate(flowNodes as IliNode[], relations);
 
-      if (initialClass) {
-        const relatedNodes = IliLayoutService.getDirectRelations(
-          initialClass,
-          flowNodes as IliNode[],
-          flowEdges,
-          colors,
-          {
-            showFullHierarchy,
-            useCurvedLines,
-            showEnums,
-            showAssociations,
-            maxSubTypesPerRow: 4,
-            useMagicLayout: false,
-          }
-        );
+      if (showOverview) {
+        const overview = layoutModelOverview(flowNodes as IliNode[], relations);
+        setNodes(overview.nodes);
+        setEdges(overview.edges);
+        setActiveNodeId(null);
+        setNavigationHistory([]);
+        setHistoryIndex(-1);
+      } else {
+        const initialClass = (
+          flowNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
+          flowNodes.find(n => n.type === 'classNode')
+        ) as IliNode | undefined;
 
-        setNodes(relatedNodes.nodes);
-        setEdges(relatedNodes.edges);
-        setActiveNodeId(initialClass.id);
-        setNavigationHistory([{
-          nodeId: initialClass.id,
-          showEnums: true,
-          showAssociations: showAssociations
-        }]);
-        setHistoryIndex(0);
+        if (initialClass) {
+          const relatedNodes = IliLayoutService.getDirectRelations(
+            initialClass,
+            flowNodes as IliNode[],
+            flowEdges,
+            colors,
+            {
+              showFullHierarchy,
+              useCurvedLines,
+              showEnums,
+              showAssociations,
+              maxSubTypesPerRow: 4,
+              useMagicLayout: false,
+            }
+          );
 
-       
-        requestAnimationFrame(() => {
-          setMaxSubTypesPerRow(4);
-        });
+          setNodes(relatedNodes.nodes);
+          setEdges(relatedNodes.edges);
+          setActiveNodeId(initialClass.id);
+          setNavigationHistory([{
+            nodeId: initialClass.id,
+            showEnums: true,
+            showAssociations: showAssociations
+          }]);
+          setHistoryIndex(0);
+
+          requestAnimationFrame(() => {
+            setMaxSubTypesPerRow(4);
+          });
+        }
       }
 
     } catch (error) {
@@ -390,14 +402,26 @@ export const useIliSchema = (
   ]);
 
   const handleReset = useCallback(() => {
-   
+
     setEnumHistory(new Map());
     setAssociationHistory(new Map());
-    
-   
+
+
     setShowEnums(true);
     setShowAssociations(true);
-    
+
+    const relations = schemaServiceRef.current.getRelations();
+
+    if (isOverviewCandidate(allNodes as IliNode[], relations)) {
+      const overview = layoutModelOverview(allNodes as IliNode[], relations);
+      setNodes(overview.nodes as IliNode[]);
+      setEdges(overview.edges);
+      setActiveNodeId(null);
+      setNavigationHistory([]);
+      setHistoryIndex(-1);
+      return;
+    }
+
     const initialClass =
       allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
       allNodes.find(n => n.type === 'classNode');
@@ -417,9 +441,32 @@ export const useIliSchema = (
       setNavigationHistory([initialState]);
       setHistoryIndex(0);
     }
-  }, [allNodes, applyLayout]);
+  }, [allNodes, applyLayout, setNodes, setEdges]);
+
+  const canGoBack = useMemo(() => {
+    if (historyIndex > 0) return true;
+    if (historyIndex === 0) {
+      const relations = schemaServiceRef.current.getRelations();
+      return isOverviewCandidate(allNodes as IliNode[], relations);
+    }
+    return false;
+  }, [historyIndex, allNodes]);
 
   const handleBack = useCallback((): boolean => {
+    if (historyIndex === 0) {
+      const relations = schemaServiceRef.current.getRelations();
+      if (isOverviewCandidate(allNodes as IliNode[], relations)) {
+        const overview = layoutModelOverview(allNodes as IliNode[], relations);
+        setNodes(overview.nodes as IliNode[]);
+        setEdges(overview.edges);
+        setActiveNodeId(null);
+        setNavigationHistory([]);
+        setHistoryIndex(-1);
+        requestFitView();
+        return true;
+      }
+      return false;
+    }
     if (historyIndex > 0) {
       const previousState = navigationHistory[historyIndex - 1];
       const previousNode = allNodes.find(node => node.id === previousState.nodeId);
@@ -697,6 +744,7 @@ export const useIliSchema = (
     handleNodeClick,
     handleReset,
     handleBack,
+    canGoBack,
     navigationHistory,
     handleHierarchyToggle,
     showFullHierarchy,

--- a/src/features/ili-explorer/services/layout/overviewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/overviewStrategy.ts
@@ -1,0 +1,113 @@
+import { Edge } from '@xyflow/react';
+import type { IliNode, IliRelation } from '../types/IliBaseTypes';
+
+const COL_W = 460;
+const ROW_H = 230;
+const TOPIC_HEADER_H = 70;
+const TOPIC_GAP = 90;
+const MAX_COLS = 4;
+const FRAME_PAD_X = 24;
+const FRAME_PAD_Y = 16;
+const NO_TOPIC = '__no_topic__';
+const NO_TOPIC_LABEL = 'Model level';
+
+function topicOf(node: IliNode): string {
+  return (node.data?.topic as string | undefined) || NO_TOPIC;
+}
+
+export function isOverviewCandidate(allNodes: IliNode[], allRelations: IliRelation[]): boolean {
+  const roots = collectRootClasses(allNodes, allRelations);
+  if (roots.length <= 1) return false;
+  const topics = new Set(roots.map(topicOf));
+  return roots.length > 1 || topics.size > 1;
+}
+
+function collectRootClasses(allNodes: IliNode[], allRelations: IliRelation[]): IliNode[] {
+  const extendsSourceIds = new Set(
+    allRelations.filter(r => r.type === 'EXTENDS').map(r => r.sourceId),
+  );
+  return allNodes.filter(n => n.type === 'classNode' && !extendsSourceIds.has(n.id));
+}
+
+export function layoutModelOverview(
+  allNodes: IliNode[],
+  allRelations: IliRelation[],
+): { nodes: IliNode[]; edges: Edge[] } {
+  const roots = collectRootClasses(allNodes, allRelations);
+
+  const byTopic = new Map<string, IliNode[]>();
+  for (const node of roots) {
+    const topic = topicOf(node);
+    const list = byTopic.get(topic) ?? [];
+    list.push(node);
+    byTopic.set(topic, list);
+  }
+
+  const orderedTopics = [...byTopic.keys()].sort((a, b) => {
+    if (a === NO_TOPIC) return 1;
+    if (b === NO_TOPIC) return -1;
+    return a.localeCompare(b);
+  });
+
+  const totalGridWidth = MAX_COLS * COL_W;
+  const placedNodes: IliNode[] = [];
+  let cursorY = 0;
+  let topicIndex = 0;
+
+  for (const topic of orderedTopics) {
+    const classes = byTopic.get(topic)!;
+    const rows = Math.max(1, Math.ceil(classes.length / MAX_COLS));
+    const groupContentH = TOPIC_HEADER_H + rows * ROW_H;
+
+    // Frame must be pushed first so it renders behind the cards.
+    placedNodes.push({
+      id: `__topic_frame_${topic}_${topicIndex}`,
+      type: 'topicFrameNode',
+      position: { x: -FRAME_PAD_X, y: cursorY - FRAME_PAD_Y },
+      draggable: false,
+      selectable: false,
+      data: {
+        width: totalGridWidth + FRAME_PAD_X * 2,
+        height: groupContentH + FRAME_PAD_Y * 2,
+        isHighlighted: false,
+        isActive: false,
+      },
+    } as unknown as IliNode);
+
+    placedNodes.push({
+      id: `__topic_label_${topic}_${topicIndex}`,
+      type: 'topicLabelNode',
+      position: { x: 0, y: cursorY },
+      draggable: false,
+      selectable: false,
+      data: {
+        label: topic === NO_TOPIC ? NO_TOPIC_LABEL : topic,
+        classCount: classes.length,
+        isOrphanGroup: topic === NO_TOPIC,
+        isHighlighted: false,
+        isActive: false,
+      },
+    } as unknown as IliNode);
+
+    const cardsStartY = cursorY + TOPIC_HEADER_H;
+    classes.forEach((cn, i) => {
+      const col = i % MAX_COLS;
+      const row = Math.floor(i / MAX_COLS);
+      placedNodes.push({
+        ...cn,
+        position: { x: col * COL_W, y: cardsStartY + row * ROW_H },
+        data: {
+          ...cn.data,
+          isHighlighted: false,
+          isActive: false,
+          expanded: false,
+        },
+      });
+    });
+
+    cursorY += groupContentH + TOPIC_GAP;
+    topicIndex++;
+  }
+
+  return { nodes: placedNodes, edges: [] };
+}


### PR DESCRIPTION
When a model has multiple root classes or topics, load now renders an overview: classes grouped per TOPIC inside dashed frames, no edges, click to drill in. Back button returns to the overview. Added topic count to model-info chips. Single-root models still land on the existing class-centered view.