### PR TITLE
fix(parser+ui): support VIEW TOPIC, soften warning wording

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -586,7 +586,7 @@ const Flow: React.FC = () => {
             sx={{ '& .MuiAlert-message': { maxWidth: '100%' } }}
           >
             <strong>{parseWarnings.length} Parser-{parseWarnings.length === 1 ? 'Warnung' : 'Warnungen'}</strong>
-            {' — das Modell wurde unvollständig erfasst. '}
+            {' — einige Stellen konnten von ModVis nicht vollständig interpretiert werden, das angezeigte Diagramm ist daher möglicherweise lückenhaft. '}
             {parseWarnings[0].line ? `Erste Stelle: Zeile ${parseWarnings[0].line}. ` : ''}
             <span style={{ opacity: 0.85 }}>{parseWarnings[0].message}</span>
           </Alert>

--- a/src/features/ili-explorer/services/parsers/ng/parser/topLevel.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser/topLevel.ts
@@ -5,6 +5,7 @@ import {
   LParen, RParen, LBracket, RBracket,
   Imports, Unqualified, Version, At, Translation, Of,
   Type, Refsystem, Symbology, Coordsystem, Contracted,
+  Topic, View,
 } from '../tokens';
 
 export function registerTopLevelRules(p: IliCstParserBuilder): void {
@@ -45,7 +46,16 @@ export function registerTopLevelRules(p: IliCstParserBuilder): void {
     p.CONSUME(Equals);
     p.MANY(() => {
       p.OR([
-        { ALT: () => p.SUBRULE(p.topicDef) },
+        // `VIEW TOPIC <Name>` muss zur topicDef-Variante, nicht zur viewDef.
+        {
+          GATE: () => {
+            const t1 = p.LA(1).tokenType;
+            if (t1 === Topic) return true;
+            if (t1 === View && p.LA(2).tokenType === Topic) return true;
+            return false;
+          },
+          ALT: () => p.SUBRULE(p.topicDef),
+        },
         { ALT: () => p.SUBRULE(p.domainSection) },
         { ALT: () => p.SUBRULE(p.importsClause) },
         { ALT: () => p.SUBRULE(p.unitSection) },
@@ -54,7 +64,10 @@ export function registerTopLevelRules(p: IliCstParserBuilder): void {
         { ALT: () => p.SUBRULE(p.enumerationDef) },
         { ALT: () => p.SUBRULE(p.associationDef) },
         { ALT: () => p.SUBRULE(p.functionDef) },
-        { ALT: () => p.SUBRULE(p.viewDef) },
+        {
+          GATE: () => p.LA(1).tokenType === View && p.LA(2).tokenType !== Topic,
+          ALT: () => p.SUBRULE(p.viewDef),
+        },
         { ALT: () => p.SUBRULE(p.graphicSkipDef) },
         { ALT: () => p.SUBRULE(p.parameterSkipDef) },
       ]);

--- a/src/features/ili-explorer/services/parsers/ng/parser/topic.ts
+++ b/src/features/ili-explorer/services/parsers/ng/parser/topic.ts
@@ -1,12 +1,15 @@
 import type { IliCstParserBuilder } from '../parser';
 import {
   Topic, End, Equals, Semicolon, Comma,
-  Identifier,
+  Identifier, View,
   Constraints, Of, Depends, On, Oid, As, Basket,
 } from '../tokens';
 
 export function registerTopicRules(p: IliCstParserBuilder): void {
   p.topicDef = p.RULE('topicDef', () => {
+    // INTERLIS 2.4 lässt `VIEW TOPIC <Name>` als Topic-Variante zu (Topic
+    // enthält dann nur Views). Das VIEW-Keyword darf hier vorne stehen.
+    p.OPTION2(() => p.CONSUME(View));
     p.CONSUME(Topic);
     p.CONSUME(Identifier, { LABEL: 'topicName' });
     p.OPTION3(() => p.SUBRULE(p.classModifier));


### PR DESCRIPTION
INTERLIS 2.4 allows `VIEW TOPIC <Name>` as a topic variant containing only views (e.g. SIA405_ABWASSER's LK topic). topicDef now accepts an optional VIEW prefix, and modelDef's OR gates dispatch by lookahead so `VIEW TOPIC` → topicDef and `VIEW <Ident>` → viewDef. Parse-warning toast rephrased to put responsibility on ModVis instead of the model.