### PR TITLE
feat(ui): hover preview in overview + external-aware roots

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -41,12 +41,14 @@ import {
   IliUnloadedClassNode,
   IliDomainEnumNode,
   IliTopicLabelNode,
-  IliTopicFrameNode
+  IliTopicFrameNode,
+  IliPreviewNode
 } from './nodes';
 import { useIliSchema } from '../hooks/useIliSchema';
 import { useDiagramExport } from '../hooks/useDiagramExport';
 import { LayoutSettings } from './sidebar/LayoutSettings';
 import { ModelInfoPanel } from './sidebar/ModelInfoPanel';
+import { layoutHoverPreview } from '../services/layout/previewStrategy';
 
 import '@xyflow/react/dist/style.css';
 import { debounce } from 'lodash';
@@ -74,6 +76,7 @@ const nodeTypes: NodeTypes = {
   unloadedClassNode: IliUnloadedClassNode,
   topicLabelNode: IliTopicLabelNode,
   topicFrameNode: IliTopicFrameNode,
+  previewNode: IliPreviewNode,
 };
 
 
@@ -363,7 +366,7 @@ const Flow: React.FC = () => {
   }, []);
 
  
-  const nodesWithHandlers = useMemo(() => 
+  const nodesWithHandlers = useMemo(() =>
     nodes.map(node => ({
       ...node,
       data: {
@@ -373,6 +376,42 @@ const Flow: React.FC = () => {
       }
     }))
   , [nodes, handleNodeExpand]);
+
+  const [hoveredClassId, setHoveredClassId] = useState<string | null>(null);
+  const [hoverPreviewEnabled, setHoverPreviewEnabled] = useState(true);
+
+  const isOverviewMode = useMemo(
+    () => nodes.some(n => n.type === 'topicLabelNode' || n.type === 'topicFrameNode'),
+    [nodes]
+  );
+
+  const handleNodeMouseEnter = useCallback((_e: React.MouseEvent, node: ReactFlowNode) => {
+    if (!isOverviewMode || !hoverPreviewEnabled) return;
+    if (node.type !== 'classNode') return;
+    setHoveredClassId(node.id);
+  }, [isOverviewMode, hoverPreviewEnabled]);
+
+  const handleNodeMouseLeave = useCallback(() => {
+    setHoveredClassId(null);
+  }, []);
+
+  const hoverPreview = useMemo(() => {
+    if (!isOverviewMode || !hoverPreviewEnabled || !hoveredClassId) {
+      return { nodes: [] as ReactFlowNode[], edges: [] as Edge[] };
+    }
+    const hovered = nodes.find(n => n.id === hoveredClassId);
+    if (!hovered) return { nodes: [], edges: [] };
+    return layoutHoverPreview(hovered, allNodes, allEdges, colors);
+  }, [isOverviewMode, hoverPreviewEnabled, hoveredClassId, nodes, allNodes, allEdges, colors]);
+
+  const renderedNodes = useMemo(
+    () => [...nodesWithHandlers, ...hoverPreview.nodes],
+    [nodesWithHandlers, hoverPreview.nodes]
+  );
+  const renderedEdges = useMemo(
+    () => [...edges, ...hoverPreview.edges],
+    [edges, hoverPreview.edges]
+  );
 
  
   const debouncedHandleMaxSubTypesChange = useCallback(
@@ -606,10 +645,12 @@ const Flow: React.FC = () => {
       />
 
       <ReactFlow
-        nodes={nodesWithHandlers}
-        edges={edges}
+        nodes={renderedNodes}
+        edges={renderedEdges}
         onConnect={handleConnect}
         onNodeClick={handleNodeClick as unknown as NodeMouseHandler}
+        onNodeMouseEnter={handleNodeMouseEnter as unknown as NodeMouseHandler}
+        onNodeMouseLeave={handleNodeMouseLeave as unknown as NodeMouseHandler}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         colorMode={mode}
@@ -672,6 +713,8 @@ const Flow: React.FC = () => {
           <LayoutSettings
             maxSubTypesPerRow={maxSubTypesPerRow}
             onMaxSubTypesChange={debouncedHandleMaxSubTypesChange}
+            hoverPreview={hoverPreviewEnabled}
+            onHoverPreviewChange={setHoverPreviewEnabled}
           />
           <IliSideToolbar
             currentFileName={currentFileName}

--- a/src/features/ili-explorer/components/nodes/IliClassNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliClassNode.tsx
@@ -298,6 +298,12 @@ export const IliClassNode = memo<IliClassNodeProps>(({ data }) => {
       />
       <Handle
         type="source"
+        position={Position.Bottom}
+        id="bottom-source"
+        style={{ opacity: 0 }}
+      />
+      <Handle
+        type="source"
         position={Position.Left}
         id="left-source"
         style={{ opacity: 0 }}

--- a/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
@@ -1,0 +1,53 @@
+import React, { memo } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Box, Typography } from '@mui/material';
+import { useTheme } from '../../../../common/theme/ThemeContext';
+
+interface IliPreviewNodeProps {
+  data: {
+    label: string;
+    isPlaceholder?: boolean;
+  };
+}
+
+export const IliPreviewNode: React.FC<IliPreviewNodeProps> = memo(({ data }) => {
+  const { colors } = useTheme();
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        px: 1.25,
+        py: 0.5,
+        borderRadius: 1,
+        border: `1px dashed ${colors.text}`,
+        bgcolor: 'background.paper',
+        color: colors.text,
+        opacity: data.isPlaceholder ? 0.4 : 0.65,
+        pointerEvents: 'none',
+        minWidth: 160,
+        maxWidth: 220,
+        textAlign: 'center',
+      }}
+    >
+      <Handle type="target" position={Position.Top} id="preview-top" style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} id="preview-bottom" style={{ opacity: 0 }} />
+      <Typography
+        variant="caption"
+        sx={{
+          fontFamily: 'monospace',
+          fontSize: '0.7rem',
+          fontStyle: data.isPlaceholder ? 'italic' : 'normal',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: 'block',
+        }}
+      >
+        {data.label}
+      </Typography>
+    </Box>
+  );
+});
+
+IliPreviewNode.displayName = 'IliPreviewNode';
+export default IliPreviewNode;

--- a/src/features/ili-explorer/components/nodes/index.ts
+++ b/src/features/ili-explorer/components/nodes/index.ts
@@ -8,3 +8,4 @@ export { IliAssociationNode } from './IliAssociationNode';
 export { IliUnloadedClassNode } from './IliUnloadedClassNode';
 export { IliTopicLabelNode } from './IliTopicLabelNode';
 export { IliTopicFrameNode } from './IliTopicFrameNode';
+export { IliPreviewNode } from './IliPreviewNode';

--- a/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
+++ b/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
@@ -17,11 +17,15 @@ import { useTheme } from '../../../../common/theme/ThemeContext';
 interface LayoutSettingsProps {
   maxSubTypesPerRow: number;
   onMaxSubTypesChange: (value: number) => void;
+  hoverPreview: boolean;
+  onHoverPreviewChange: (value: boolean) => void;
 }
 
 export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
   maxSubTypesPerRow,
-  onMaxSubTypesChange
+  onMaxSubTypesChange,
+  hoverPreview,
+  onHoverPreviewChange,
 }) => {
   const { colors } = useTheme();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -174,7 +178,7 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
               step={1}
               marks={marks}
               disabled={!limitSubTypes}
-              sx={{ 
+              sx={{
                 mt: 1,
                 '& .MuiSlider-mark': {
                   height: 8,
@@ -185,6 +189,22 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
                 }
               }}
             />
+          </Box>
+
+          <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={hoverPreview}
+                  onChange={(e) => onHoverPreviewChange(e.target.checked)}
+                  size="small"
+                />
+              }
+              label="Hover-Preview in Overview"
+            />
+            <Typography variant="caption" sx={{ display: 'block', mt: 0.5, opacity: 0.7 }}>
+              Zeigt beim Überfahren einer Klasse in der Overview die nächsten zwei Subtyp-Ebenen.
+            </Typography>
           </Box>
         </Box>
       </Popover>

--- a/src/features/ili-explorer/services/layout/overviewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/overviewStrategy.ts
@@ -23,10 +23,24 @@ export function isOverviewCandidate(allNodes: IliNode[], allRelations: IliRelati
 }
 
 function collectRootClasses(allNodes: IliNode[], allRelations: IliRelation[]): IliNode[] {
-  const extendsSourceIds = new Set(
-    allRelations.filter(r => r.type === 'EXTENDS').map(r => r.sourceId),
+  const externalIds = new Set(
+    allNodes.filter(n => (n.data as { isExternal?: boolean } | undefined)?.isExternal).map(n => n.id),
   );
-  return allNodes.filter(n => n.type === 'classNode' && !extendsSourceIds.has(n.id));
+  // A class counts as a root if it does NOT extend something that is part of
+  // this model. Classes that only extend external (imported) classes are still
+  // shown as roots — the external supertype isn't really part of this model's
+  // structure, so the local class is the actual entry point.
+  const extendsToInternal = new Set<string>();
+  for (const rel of allRelations) {
+    if (rel.type !== 'EXTENDS') continue;
+    if (externalIds.has(rel.targetId)) continue;
+    extendsToInternal.add(rel.sourceId);
+  }
+  return allNodes.filter(n =>
+    n.type === 'classNode'
+    && !(n.data as { isExternal?: boolean } | undefined)?.isExternal
+    && !extendsToInternal.has(n.id),
+  );
 }
 
 export function layoutModelOverview(

--- a/src/features/ili-explorer/services/layout/previewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/previewStrategy.ts
@@ -1,0 +1,179 @@
+import { Edge, Node } from '@xyflow/react';
+import type { ThemeColors } from '../../../../common/theme/ThemeContext';
+
+const PREVIEW_W = 180;
+const PREVIEW_GAP_X = 24;
+const LEVEL_GAP_Y = 70;
+const HOVERED_W_FALLBACK = 400;
+const HOVERED_H_FALLBACK = 150;
+const MAX_PER_LEVEL = 6;
+const MAX_LEVEL2_PER_PARENT = 4;
+
+interface PreviewInputNode {
+  id: string;
+  type?: string;
+  position: { x: number; y: number };
+  width?: number;
+  height?: number;
+  data?: { label?: string; [k: string]: unknown };
+}
+
+interface PreviewInputEdge {
+  source: string;
+  target: string;
+}
+
+function findSubtypes(parentId: string, edges: PreviewInputEdge[]): string[] {
+  return edges.filter(e => e.target === parentId).map(e => e.source);
+}
+
+export function layoutHoverPreview(
+  hoveredNode: PreviewInputNode,
+  allNodes: PreviewInputNode[],
+  inheritanceEdges: PreviewInputEdge[],
+  colors: ThemeColors,
+): { nodes: Node[]; edges: Edge[] } {
+  const nodeById = new Map(allNodes.map(n => [n.id, n]));
+  const directSubIds = findSubtypes(hoveredNode.id, inheritanceEdges);
+  if (directSubIds.length === 0) return { nodes: [], edges: [] };
+
+  const hoveredW = hoveredNode.width ?? HOVERED_W_FALLBACK;
+  const hoveredH = hoveredNode.height ?? HOVERED_H_FALLBACK;
+  const hCenterX = hoveredNode.position.x + hoveredW / 2;
+  const hBottomY = hoveredNode.position.y + hoveredH;
+
+  const visibleLevel1 = directSubIds.slice(0, MAX_PER_LEVEL);
+  const overflowLevel1 = directSubIds.length - visibleLevel1.length;
+
+  const level1Y = hBottomY + LEVEL_GAP_Y;
+  const level1Count = visibleLevel1.length + (overflowLevel1 > 0 ? 1 : 0);
+  const level1TotalW = level1Count * PREVIEW_W + (level1Count - 1) * PREVIEW_GAP_X;
+  const level1StartX = hCenterX - level1TotalW / 2;
+
+  const previewNodes: Node[] = [];
+  const previewEdges: Edge[] = [];
+  const edgeStyle = {
+    stroke: colors.text,
+    strokeWidth: 1,
+    strokeDasharray: '4,4',
+    opacity: 0.4,
+  };
+
+  visibleLevel1.forEach((subId, i) => {
+    const sub = nodeById.get(subId);
+    const label = (sub?.data?.label as string | undefined) ?? subId;
+    const x = level1StartX + i * (PREVIEW_W + PREVIEW_GAP_X);
+    const previewId = `__preview_l1_${subId}`;
+
+    previewNodes.push({
+      id: previewId,
+      type: 'previewNode',
+      position: { x, y: level1Y },
+      draggable: false,
+      selectable: false,
+      data: { label },
+    } as Node);
+
+    previewEdges.push({
+      id: `__preview_edge_${hoveredNode.id}_${subId}`,
+      source: hoveredNode.id,
+      sourceHandle: 'bottom-source',
+      target: previewId,
+      targetHandle: 'preview-top',
+      type: 'default',
+      style: edgeStyle,
+      animated: false,
+    });
+
+    // Level 2: subtypes of this level-1 sub
+    const level2Ids = findSubtypes(subId, inheritanceEdges);
+    if (level2Ids.length === 0) return;
+
+    const visibleLevel2 = level2Ids.slice(0, MAX_LEVEL2_PER_PARENT);
+    const overflowLevel2 = level2Ids.length - visibleLevel2.length;
+    const l2Count = visibleLevel2.length + (overflowLevel2 > 0 ? 1 : 0);
+    const l2Y = level1Y + LEVEL_GAP_Y + 30;
+
+    // Center under the level-1 box
+    const l1CenterX = x + PREVIEW_W / 2;
+    const l2NarrowW = 140;
+    const l2GapX = 16;
+    const l2TotalW = l2Count * l2NarrowW + (l2Count - 1) * l2GapX;
+    const l2StartX = l1CenterX - l2TotalW / 2;
+
+    visibleLevel2.forEach((sub2Id, j) => {
+      const sub2 = nodeById.get(sub2Id);
+      const label2 = (sub2?.data?.label as string | undefined) ?? sub2Id;
+      const x2 = l2StartX + j * (l2NarrowW + l2GapX);
+      const previewId2 = `__preview_l2_${subId}_${sub2Id}`;
+
+      previewNodes.push({
+        id: previewId2,
+        type: 'previewNode',
+        position: { x: x2, y: l2Y },
+        draggable: false,
+        selectable: false,
+        data: { label: label2 },
+      } as Node);
+
+      previewEdges.push({
+        id: `__preview_edge_${subId}_${sub2Id}`,
+        source: previewId,
+        sourceHandle: 'preview-bottom',
+        target: previewId2,
+        targetHandle: 'preview-top',
+        type: 'default',
+        style: edgeStyle,
+        animated: false,
+      });
+    });
+
+    if (overflowLevel2 > 0) {
+      const x2 = l2StartX + visibleLevel2.length * (l2NarrowW + l2GapX);
+      const placeholderId = `__preview_l2_more_${subId}`;
+      previewNodes.push({
+        id: placeholderId,
+        type: 'previewNode',
+        position: { x: x2, y: l2Y },
+        draggable: false,
+        selectable: false,
+        data: { label: `+${overflowLevel2} more`, isPlaceholder: true },
+      } as Node);
+      previewEdges.push({
+        id: `__preview_edge_${subId}_more`,
+        source: previewId,
+        sourceHandle: 'preview-bottom',
+        target: placeholderId,
+        targetHandle: 'preview-top',
+        type: 'default',
+        style: edgeStyle,
+        animated: false,
+      });
+    }
+  });
+
+  if (overflowLevel1 > 0) {
+    const x = level1StartX + visibleLevel1.length * (PREVIEW_W + PREVIEW_GAP_X);
+    const placeholderId = `__preview_l1_more`;
+    previewNodes.push({
+      id: placeholderId,
+      type: 'previewNode',
+      position: { x, y: level1Y },
+      draggable: false,
+      selectable: false,
+      data: { label: `+${overflowLevel1} more`, isPlaceholder: true },
+    } as Node);
+    previewEdges.push({
+      id: `__preview_edge_${hoveredNode.id}_more`,
+      source: hoveredNode.id,
+      sourceHandle: 'bottom-source',
+      target: placeholderId,
+      targetHandle: 'preview-top',
+      type: 'default',
+      style: edgeStyle,
+      animated: false,
+    });
+  }
+
+  return { nodes: previewNodes, edges: previewEdges };
+}


### PR DESCRIPTION
Hovering a class in the overview now reveals the next two subtype levels as slim grey dashed boxes connected by lines (toggleable in Layout-Settings). Added a bottom-source handle on classNode so preview edges actually exit downward. collectRootClasses now skips external imports and treats classes that extend only externals as proper roots.