### PR TITLE
refactor(ui): consolidate Reset into Overview, move hierarchy to sett…

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -12,7 +12,6 @@ import {
   Edge,
   MarkerType,
   useReactFlow,
-  useNodesInitialized,
   EdgeTypes,
   BezierEdge,
   StepEdge,
@@ -132,11 +131,10 @@ const Flow: React.FC = () => {
     handleClearFile,
     handleConnect,
     handleNodeClick: baseHandleNodeClick,
-    handleReset: baseHandleReset,
     handleBack: baseHandleBack,
     canGoBack,
     showOverview,
-    handleHierarchyToggle,
+    setFullHierarchyAndReset,
     activeNodeId,
     setActiveNodeId,
     allNodes,
@@ -168,26 +166,35 @@ const Flow: React.FC = () => {
     setUseCurvedLines(true);
   }, [handleFileUploadBase]);
 
-  const nodesInitialized = useNodesInitialized();
   const [lastFitDone, setLastFitDone] = useState(0);
   const canvasReady = fitViewRequest === 0 || lastFitDone === fitViewRequest;
 
+  // Two rAFs: first commits the new node array to the DOM, second runs after
+  // React Flow's ResizeObserver has reported dimensions for the freshly
+  // mounted nodes. fitView then has correct measurements without needing
+  // useNodesInitialized (which doesn't reliably flip when node IDs overlap
+  // between layouts).
   useEffect(() => {
     if (fitViewRequest === 0) return;
     if (lastFitDone === fitViewRequest) return;
-    if (!nodesInitialized) return;
     if (nodes.length === 0) return;
 
-    const id = requestAnimationFrame(() => {
-      fitView({
-        ...DEFAULT_FIT_VIEW_OPTIONS,
-        duration: 600,
-        padding: 0.3,
+    let raf2: number | null = null;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        fitView({
+          ...DEFAULT_FIT_VIEW_OPTIONS,
+          duration: 600,
+          padding: 0.3,
+        });
+        setLastFitDone(fitViewRequest);
       });
-      setLastFitDone(fitViewRequest);
     });
-    return () => cancelAnimationFrame(id);
-  }, [nodesInitialized, nodes.length, fitView, fitViewRequest, lastFitDone]);
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2 !== null) cancelAnimationFrame(raf2);
+    };
+  }, [nodes.length, fitView, fitViewRequest, lastFitDone]);
 
   const handleLineTypeToggle = useCallback(() => {
     const newCurvedLines = !useCurvedLines;
@@ -243,14 +250,6 @@ const Flow: React.FC = () => {
     const currentViewport = getViewport();
     baseHandleNodeClick(event, iliNode, currentViewport);
   }, [activeNodeId, baseHandleNodeClick, getViewport]);
-
-  const handleReset = useCallback(() => {
-    baseHandleReset();
-
-    setMaxSubTypesPerRow(4);
-    setUseCurvedLines(true);
-    requestFitView();
-  }, [baseHandleReset, requestFitView, setMaxSubTypesPerRow]);
 
   const handleBack = useCallback(() => {
     if (historyIndex < 0) return;
@@ -380,29 +379,52 @@ const Flow: React.FC = () => {
   const [hoveredClassId, setHoveredClassId] = useState<string | null>(null);
   const [hoverPreviewEnabled, setHoverPreviewEnabled] = useState(true);
 
-  const isOverviewMode = useMemo(
-    () => nodes.some(n => n.type === 'topicLabelNode' || n.type === 'topicFrameNode'),
-    [nodes]
-  );
+  // Walk up the EXTENDS chain from the active class — every ancestor (direct
+  // parent, grandparent, …) is already represented in the current view, so
+  // hover preview on any of them would duplicate what's visible.
+  const activeSupertypeIds = useMemo(() => {
+    if (!activeNodeId) return new Set<string>();
+    const seen = new Set<string>();
+    const queue: string[] = [activeNodeId];
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+      for (const e of allEdges) {
+        if (e.source === id && !seen.has(e.target)) {
+          seen.add(e.target);
+          queue.push(e.target);
+        }
+      }
+    }
+    return seen;
+  }, [activeNodeId, allEdges]);
 
   const handleNodeMouseEnter = useCallback((_e: React.MouseEvent, node: ReactFlowNode) => {
-    if (!isOverviewMode || !hoverPreviewEnabled) return;
+    if (!hoverPreviewEnabled) return;
     if (node.type !== 'classNode') return;
+    if (node.id === activeNodeId) return;
+    if (activeSupertypeIds.has(node.id)) return;
+    if ((node.data as { expanded?: boolean } | undefined)?.expanded) return;
     setHoveredClassId(node.id);
-  }, [isOverviewMode, hoverPreviewEnabled]);
+  }, [hoverPreviewEnabled, activeNodeId, activeSupertypeIds]);
 
   const handleNodeMouseLeave = useCallback(() => {
     setHoveredClassId(null);
   }, []);
 
   const hoverPreview = useMemo(() => {
-    if (!isOverviewMode || !hoverPreviewEnabled || !hoveredClassId) {
+    if (!hoverPreviewEnabled || !hoveredClassId) {
       return { nodes: [] as ReactFlowNode[], edges: [] as Edge[] };
+    }
+    if (activeSupertypeIds.has(hoveredClassId)) {
+      return { nodes: [], edges: [] };
     }
     const hovered = nodes.find(n => n.id === hoveredClassId);
     if (!hovered) return { nodes: [], edges: [] };
+    if ((hovered.data as { expanded?: boolean } | undefined)?.expanded) {
+      return { nodes: [], edges: [] };
+    }
     return layoutHoverPreview(hovered, allNodes, allEdges, colors);
-  }, [isOverviewMode, hoverPreviewEnabled, hoveredClassId, nodes, allNodes, allEdges, colors]);
+  }, [hoverPreviewEnabled, hoveredClassId, nodes, allNodes, allEdges, colors, activeSupertypeIds]);
 
   const renderedNodes = useMemo(
     () => [...nodesWithHandlers, ...hoverPreview.nodes],
@@ -715,6 +737,8 @@ const Flow: React.FC = () => {
             onMaxSubTypesChange={debouncedHandleMaxSubTypesChange}
             hoverPreview={hoverPreviewEnabled}
             onHoverPreviewChange={setHoverPreviewEnabled}
+            fullHierarchy={showFullHierarchy}
+            onFullHierarchyChange={setFullHierarchyAndReset}
           />
           <IliSideToolbar
             currentFileName={currentFileName}
@@ -722,12 +746,9 @@ const Flow: React.FC = () => {
             historyIndex={historyIndex}
             canGoBack={canGoBack}
             onShowOverview={showOverview}
-            showFullHierarchy={showFullHierarchy}
             useCurvedLines={useCurvedLines}
             exportAnchorEl={exportAnchorEl}
-            onReset={handleReset}
             onBack={handleBack}
-            onHierarchyToggle={handleHierarchyToggle}
             onLineTypeToggle={handleLineTypeToggle}
             onMagicLayout={handleMagicLayout}
             onCollapseAll={handleCollapseAll}

--- a/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
@@ -18,29 +18,31 @@ export const IliPreviewNode: React.FC<IliPreviewNodeProps> = memo(({ data }) => 
         position: 'relative',
         px: 1.25,
         py: 0.5,
-        borderRadius: 1,
-        border: `1px dashed ${colors.text}`,
+        borderRadius: 0.5,
+        border: '1px solid #555',
         bgcolor: 'background.paper',
         color: colors.text,
-        opacity: data.isPlaceholder ? 0.4 : 0.65,
         pointerEvents: 'none',
-        minWidth: 160,
-        maxWidth: 220,
+        width: 180,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+        opacity: data.isPlaceholder ? 0.65 : 1,
         textAlign: 'center',
       }}
     >
-      <Handle type="target" position={Position.Top} id="preview-top" style={{ opacity: 0 }} />
+      <Handle type="target" position={Position.Left} id="preview-left" style={{ opacity: 0 }} />
       <Handle type="source" position={Position.Bottom} id="preview-bottom" style={{ opacity: 0 }} />
       <Typography
         variant="caption"
         sx={{
           fontFamily: 'monospace',
-          fontSize: '0.7rem',
+          fontSize: '0.72rem',
+          fontWeight: data.isPlaceholder ? 400 : 500,
           fontStyle: data.isPlaceholder ? 'italic' : 'normal',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           display: 'block',
+          letterSpacing: 0.2,
         }}
       >
         {data.label}

--- a/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
+++ b/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
@@ -19,6 +19,8 @@ interface LayoutSettingsProps {
   onMaxSubTypesChange: (value: number) => void;
   hoverPreview: boolean;
   onHoverPreviewChange: (value: boolean) => void;
+  fullHierarchy: boolean;
+  onFullHierarchyChange: (value: boolean) => void;
 }
 
 export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
@@ -26,6 +28,8 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
   onMaxSubTypesChange,
   hoverPreview,
   onHoverPreviewChange,
+  fullHierarchy,
+  onFullHierarchyChange,
 }) => {
   const { colors } = useTheme();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -200,10 +204,26 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
                   size="small"
                 />
               }
-              label="Hover-Preview in Overview"
+              label="Hover-Preview"
             />
             <Typography variant="caption" sx={{ display: 'block', mt: 0.5, opacity: 0.7 }}>
-              Zeigt beim Überfahren einer Klasse in der Overview die nächsten zwei Subtyp-Ebenen.
+              Zeigt beim Überfahren einer Klasse die nächsten zwei Subtyp-Ebenen als kleine Vorschau-Boxen.
+            </Typography>
+          </Box>
+
+          <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={fullHierarchy}
+                  onChange={(e) => onFullHierarchyChange(e.target.checked)}
+                  size="small"
+                />
+              }
+              label="Vollständige Hierarchie anzeigen"
+            />
+            <Typography variant="caption" sx={{ display: 'block', mt: 0.5, opacity: 0.7 }}>
+              Beim Umschalten wird die Ansicht zurückgesetzt.
             </Typography>
           </Box>
         </Box>

--- a/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
+++ b/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
@@ -9,8 +9,6 @@ import {
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import {
-  AccountTree,
-  Refresh,
   ArrowBack,
   AutoFixHigh,
   ExpandMore,
@@ -26,13 +24,10 @@ interface IliSideToolbarProps {
   activeNodeId: string | null;
   historyIndex: number;
   canGoBack?: boolean;
-  showFullHierarchy: boolean;
   useCurvedLines: boolean;
   exportAnchorEl: HTMLElement | null;
   onShowOverview: () => void;
-  onReset: () => void;
   onBack: () => void;
-  onHierarchyToggle: () => void;
   onLineTypeToggle: () => void;
   onMagicLayout: () => void;
   onCollapseAll: () => void;
@@ -49,13 +44,10 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
   activeNodeId,
   historyIndex,
   canGoBack,
-  showFullHierarchy,
   useCurvedLines,
   exportAnchorEl,
   onShowOverview,
-  onReset,
   onBack,
-  onHierarchyToggle,
   onLineTypeToggle,
   onMagicLayout,
   onCollapseAll,
@@ -94,18 +86,10 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         },
       }}
     >
-      <Tooltip title="Overview" placement="right">
+      <Tooltip title="Overview / Ansicht zurücksetzen" placement="right">
         <span>
           <IconButton size="small" onClick={onShowOverview} disabled={noSchema} aria-label="Show overview">
             <GridView fontSize="small" />
-          </IconButton>
-        </span>
-      </Tooltip>
-
-      <Tooltip title="Ansicht zurücksetzen" placement="right">
-        <span>
-          <IconButton size="small" onClick={onReset} disabled={noSchema} aria-label="Reset view">
-            <Refresh fontSize="small" />
           </IconButton>
         </span>
       </Tooltip>
@@ -114,20 +98,6 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         <span>
           <IconButton size="small" onClick={onBack} disabled={canGoBack === undefined ? historyIndex <= 0 : !canGoBack} aria-label="Go back">
             <ArrowBack fontSize="small" />
-          </IconButton>
-        </span>
-      </Tooltip>
-
-      <Tooltip title="Vollständige Hierarchie anzeigen" placement="right">
-        <span>
-          <IconButton
-            size="small"
-            onClick={onHierarchyToggle}
-            disabled={noNode}
-            sx={{ color: showFullHierarchy ? colors.active : 'default' }}
-            aria-label="Toggle hierarchy view"
-          >
-            <AccountTree fontSize="small" />
           </IconButton>
         </span>
       </Tooltip>

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -43,10 +43,9 @@ interface UseIliSchemaReturn {
   handleClearFile: () => void;
   handleConnect: (params: Connection) => void;
   handleNodeClick: (event: React.MouseEvent, node: Node, viewport: ViewportState) => void;
-  handleReset: () => void;
   handleBack: () => boolean;
   navigationHistory: NavigationState[];
-  handleHierarchyToggle: () => void;
+  setFullHierarchyAndReset: (value: boolean) => void;
   showFullHierarchy: boolean;
   activeNodeId: string | null;
   setActiveNodeId: (id: string | null) => void;
@@ -408,58 +407,23 @@ export const useIliSchema = (
     requestFitView,
   ]);
 
-  const handleReset = useCallback(() => {
-
-    setEnumHistory(new Map());
-    setAssociationHistory(new Map());
-
-
-    setShowEnums(true);
-    setShowAssociations(true);
-
-    const relations = schemaServiceRef.current.getRelations();
-
-    if (isOverviewCandidate(allNodes as IliNode[], relations)) {
-      const overview = layoutModelOverview(allNodes as IliNode[], relations);
-      setNodes(overview.nodes as IliNode[]);
-      setEdges(overview.edges);
-      setActiveNodeId(null);
-      setNavigationHistory([]);
-      setHistoryIndex(-1);
-      setOverviewWasShown(true);
-      return;
-    }
-
-    setOverviewWasShown(false);
-    const initialClass =
-      allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
-      allNodes.find(n => n.type === 'classNode');
-
-    if (initialClass) {
-      applyLayout(initialClass as IliNode, {
-        showEnums: true,
-        showAssociations: true,
-      });
-      setActiveNodeId(initialClass.id);
-
-      const initialState: NavigationState = {
-        nodeId: initialClass.id,
-        showEnums: true,
-        showAssociations: true
-      };
-      setNavigationHistory([initialState]);
-      setHistoryIndex(0);
-    }
-  }, [allNodes, applyLayout, setNodes, setEdges]);
-
   const canGoBack = useMemo(() => {
     if (historyIndex > 0) return true;
     if (historyIndex === 0) return overviewWasShown;
     return false;
   }, [historyIndex, overviewWasShown]);
 
+  // Single entry point that returns the user to the initial state for the
+  // current model: renders the topic-grouped overview and resets all
+  // session-only toggles (enum/association history, visibility flags, max
+  // sub-types per row). Replaces the previous Reset action.
   const showOverview = useCallback(() => {
     if (allNodes.length === 0) return;
+    setEnumHistory(new Map());
+    setAssociationHistory(new Map());
+    setShowEnums(true);
+    setShowAssociations(true);
+    setMaxSubTypesPerRow(4);
     const relations = schemaServiceRef.current.getRelations();
     const overview = layoutModelOverview(allNodes as IliNode[], relations);
     setNodes(overview.nodes as IliNode[]);
@@ -546,10 +510,53 @@ export const useIliSchema = (
     setAssociationHistory(new Map());
   }, [setNodes, setEdges]);
 
-  const handleHierarchyToggle = useCallback(() => {
-    setShowFullHierarchy(prev => !prev);
-    return true;
-  }, []);
+  // Setting full-hierarchy from the layout-settings panel: flip the flag and
+  // bring the user back to the initial view (overview if multi-root, else the
+  // abstract base class) using the new value as override so the closure
+  // staleness from setShowFullHierarchy doesn't matter.
+  const setFullHierarchyAndReset = useCallback((value: boolean) => {
+    setShowFullHierarchy(value);
+    setEnumHistory(new Map());
+    setAssociationHistory(new Map());
+    setShowEnums(true);
+    setShowAssociations(true);
+
+    const relations = schemaServiceRef.current.getRelations();
+    if (isOverviewCandidate(allNodes as IliNode[], relations)) {
+      const overview = layoutModelOverview(allNodes as IliNode[], relations);
+      setNodes(overview.nodes as IliNode[]);
+      setEdges(overview.edges);
+      setActiveNodeId(null);
+      setNavigationHistory([]);
+      setHistoryIndex(-1);
+      setOverviewWasShown(true);
+      requestFitView();
+      return;
+    }
+
+    setOverviewWasShown(false);
+    const initialClass =
+      allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
+      allNodes.find(n => n.type === 'classNode');
+    if (initialClass) {
+      const result = computeLayout(initialClass as IliNode, {
+        showFullHierarchy: value,
+        showEnums: true,
+        showAssociations: true,
+        maxSubTypesPerRow: 4,
+      });
+      setNodes(result.nodes);
+      setEdges(result.edges);
+      setActiveNodeId(initialClass.id);
+      setNavigationHistory([{
+        nodeId: initialClass.id,
+        showEnums: true,
+        showAssociations: true,
+      }]);
+      setHistoryIndex(0);
+      requestFitView();
+    }
+  }, [allNodes, computeLayout, setNodes, setEdges, requestFitView]);
 
   const handleToggleEnums = useCallback((visible: boolean) => {
     setShowEnums(visible);
@@ -763,12 +770,11 @@ export const useIliSchema = (
     handleClearFile,
     handleConnect,
     handleNodeClick,
-    handleReset,
     handleBack,
     canGoBack,
     showOverview,
     navigationHistory,
-    handleHierarchyToggle,
+    setFullHierarchyAndReset,
     showFullHierarchy,
     activeNodeId,
     setActiveNodeId,

--- a/src/features/ili-explorer/services/layout/previewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/previewStrategy.ts
@@ -1,13 +1,22 @@
-import { Edge, Node } from '@xyflow/react';
+import { Edge, Node, MarkerType } from '@xyflow/react';
+import type { EdgeMarker } from '@xyflow/react';
 import type { ThemeColors } from '../../../../common/theme/ThemeContext';
 
 const PREVIEW_W = 180;
-const PREVIEW_GAP_X = 24;
-const LEVEL_GAP_Y = 70;
+const PREVIEW_H = 28;
+const SIBLING_GAP_Y = 10;
+const FIRST_OFFSET_Y = 32;
 const HOVERED_W_FALLBACK = 400;
 const HOVERED_H_FALLBACK = 150;
-const MAX_PER_LEVEL = 6;
-const MAX_LEVEL2_PER_PARENT = 4;
+const MAX_PER_LEVEL = 8;
+const MAX_DEPTH = 2;
+// Trunk emerges from the hovered class's bottom-center; boxes sit clearly to
+// the right of that trunk so the L-corner has room to breathe.
+const TRUNK_TO_BOX_GAP = 70;
+// Level-N child must start to the right of its parent's bottom-center
+// (= parent.x + PREVIEW_W/2), otherwise the L-edge bends backwards.
+const INDENT_X = PREVIEW_W / 2 + TRUNK_TO_BOX_GAP;
+const PREVIEW_Z_INDEX = 1000;
 
 interface PreviewInputNode {
   id: string;
@@ -27,13 +36,122 @@ function findSubtypes(parentId: string, edges: PreviewInputEdge[]): string[] {
   return edges.filter(e => e.target === parentId).map(e => e.source);
 }
 
+interface LayoutCtx {
+  nodeById: Map<string, PreviewInputNode>;
+  inheritanceEdges: PreviewInputEdge[];
+  edgeStyle: React.CSSProperties;
+  markerEnd: EdgeMarker;
+  outNodes: Node[];
+  outEdges: Edge[];
+}
+
+function pushPreviewNode(
+  ctx: LayoutCtx,
+  id: string,
+  label: string,
+  x: number,
+  y: number,
+  isPlaceholder = false,
+): void {
+  ctx.outNodes.push({
+    id,
+    type: 'previewNode',
+    position: { x, y },
+    draggable: false,
+    selectable: false,
+    zIndex: PREVIEW_Z_INDEX,
+    data: { label, isPlaceholder },
+  } as Node);
+}
+
+function pushPreviewEdge(
+  ctx: LayoutCtx,
+  id: string,
+  source: string,
+  sourceHandle: string,
+  target: string,
+): void {
+  ctx.outEdges.push({
+    id,
+    source,
+    sourceHandle,
+    target,
+    targetHandle: 'preview-left',
+    type: 'step',
+    style: ctx.edgeStyle,
+    markerEnd: ctx.markerEnd,
+    animated: false,
+    zIndex: PREVIEW_Z_INDEX,
+  });
+}
+
+function layoutChildren(
+  ctx: LayoutCtx,
+  parentLookupId: string,
+  edgeSourceId: string,
+  edgeSourceHandle: string,
+  startX: number,
+  startY: number,
+  depth: number,
+): number {
+  const children = findSubtypes(parentLookupId, ctx.inheritanceEdges);
+  if (children.length === 0) return startY;
+
+  const visible = children.slice(0, MAX_PER_LEVEL);
+  const overflow = children.length - visible.length;
+  let cursorY = startY;
+
+  visible.forEach((childId, i) => {
+    const childNode = ctx.nodeById.get(childId);
+    const label = (childNode?.data?.label as string | undefined) ?? childId;
+    const previewId = `__preview_${edgeSourceId}_${depth}_${i}_${childId}`;
+
+    pushPreviewNode(ctx, previewId, label, startX, cursorY);
+    pushPreviewEdge(
+      ctx,
+      `__preview_edge_${edgeSourceId}_${depth}_${i}`,
+      edgeSourceId,
+      edgeSourceHandle,
+      previewId,
+    );
+
+    cursorY += PREVIEW_H + SIBLING_GAP_Y;
+
+    if (depth < MAX_DEPTH) {
+      cursorY = layoutChildren(
+        ctx,
+        childId,
+        previewId,
+        'preview-bottom',
+        startX + INDENT_X,
+        cursorY,
+        depth + 1,
+      );
+    }
+  });
+
+  if (overflow > 0) {
+    const placeholderId = `__preview_${edgeSourceId}_${depth}_more`;
+    pushPreviewNode(ctx, placeholderId, `+${overflow} more`, startX, cursorY, true);
+    pushPreviewEdge(
+      ctx,
+      `__preview_edge_${edgeSourceId}_${depth}_more`,
+      edgeSourceId,
+      edgeSourceHandle,
+      placeholderId,
+    );
+    cursorY += PREVIEW_H + SIBLING_GAP_Y;
+  }
+
+  return cursorY;
+}
+
 export function layoutHoverPreview(
   hoveredNode: PreviewInputNode,
   allNodes: PreviewInputNode[],
   inheritanceEdges: PreviewInputEdge[],
   colors: ThemeColors,
 ): { nodes: Node[]; edges: Edge[] } {
-  const nodeById = new Map(allNodes.map(n => [n.id, n]));
   const directSubIds = findSubtypes(hoveredNode.id, inheritanceEdges);
   if (directSubIds.length === 0) return { nodes: [], edges: [] };
 
@@ -42,138 +160,41 @@ export function layoutHoverPreview(
   const hCenterX = hoveredNode.position.x + hoveredW / 2;
   const hBottomY = hoveredNode.position.y + hoveredH;
 
-  const visibleLevel1 = directSubIds.slice(0, MAX_PER_LEVEL);
-  const overflowLevel1 = directSubIds.length - visibleLevel1.length;
+  // Boxes sit to the right of the trunk (which exits class.bottom-center).
+  const startX = hCenterX + TRUNK_TO_BOX_GAP;
+  const startY = hBottomY + FIRST_OFFSET_Y;
 
-  const level1Y = hBottomY + LEVEL_GAP_Y;
-  const level1Count = visibleLevel1.length + (overflowLevel1 > 0 ? 1 : 0);
-  const level1TotalW = level1Count * PREVIEW_W + (level1Count - 1) * PREVIEW_GAP_X;
-  const level1StartX = hCenterX - level1TotalW / 2;
-
-  const previewNodes: Node[] = [];
-  const previewEdges: Edge[] = [];
-  const edgeStyle = {
-    stroke: colors.text,
-    strokeWidth: 1,
-    strokeDasharray: '4,4',
-    opacity: 0.4,
+  const lineColor = '#555';
+  const ctx: LayoutCtx = {
+    nodeById: new Map(allNodes.map(n => [n.id, n])),
+    inheritanceEdges,
+    edgeStyle: {
+      stroke: lineColor,
+      strokeWidth: 1,
+      opacity: 0.9,
+    },
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      color: lineColor,
+      width: 14,
+      height: 14,
+    },
+    outNodes: [],
+    outEdges: [],
   };
+  // colors is intentionally unused now that the preview uses a fixed dark
+  // grey — keep the parameter to preserve the call signature for callers.
+  void colors;
 
-  visibleLevel1.forEach((subId, i) => {
-    const sub = nodeById.get(subId);
-    const label = (sub?.data?.label as string | undefined) ?? subId;
-    const x = level1StartX + i * (PREVIEW_W + PREVIEW_GAP_X);
-    const previewId = `__preview_l1_${subId}`;
+  layoutChildren(
+    ctx,
+    hoveredNode.id,
+    hoveredNode.id,
+    'bottom-source',
+    startX,
+    startY,
+    1,
+  );
 
-    previewNodes.push({
-      id: previewId,
-      type: 'previewNode',
-      position: { x, y: level1Y },
-      draggable: false,
-      selectable: false,
-      data: { label },
-    } as Node);
-
-    previewEdges.push({
-      id: `__preview_edge_${hoveredNode.id}_${subId}`,
-      source: hoveredNode.id,
-      sourceHandle: 'bottom-source',
-      target: previewId,
-      targetHandle: 'preview-top',
-      type: 'default',
-      style: edgeStyle,
-      animated: false,
-    });
-
-    // Level 2: subtypes of this level-1 sub
-    const level2Ids = findSubtypes(subId, inheritanceEdges);
-    if (level2Ids.length === 0) return;
-
-    const visibleLevel2 = level2Ids.slice(0, MAX_LEVEL2_PER_PARENT);
-    const overflowLevel2 = level2Ids.length - visibleLevel2.length;
-    const l2Count = visibleLevel2.length + (overflowLevel2 > 0 ? 1 : 0);
-    const l2Y = level1Y + LEVEL_GAP_Y + 30;
-
-    // Center under the level-1 box
-    const l1CenterX = x + PREVIEW_W / 2;
-    const l2NarrowW = 140;
-    const l2GapX = 16;
-    const l2TotalW = l2Count * l2NarrowW + (l2Count - 1) * l2GapX;
-    const l2StartX = l1CenterX - l2TotalW / 2;
-
-    visibleLevel2.forEach((sub2Id, j) => {
-      const sub2 = nodeById.get(sub2Id);
-      const label2 = (sub2?.data?.label as string | undefined) ?? sub2Id;
-      const x2 = l2StartX + j * (l2NarrowW + l2GapX);
-      const previewId2 = `__preview_l2_${subId}_${sub2Id}`;
-
-      previewNodes.push({
-        id: previewId2,
-        type: 'previewNode',
-        position: { x: x2, y: l2Y },
-        draggable: false,
-        selectable: false,
-        data: { label: label2 },
-      } as Node);
-
-      previewEdges.push({
-        id: `__preview_edge_${subId}_${sub2Id}`,
-        source: previewId,
-        sourceHandle: 'preview-bottom',
-        target: previewId2,
-        targetHandle: 'preview-top',
-        type: 'default',
-        style: edgeStyle,
-        animated: false,
-      });
-    });
-
-    if (overflowLevel2 > 0) {
-      const x2 = l2StartX + visibleLevel2.length * (l2NarrowW + l2GapX);
-      const placeholderId = `__preview_l2_more_${subId}`;
-      previewNodes.push({
-        id: placeholderId,
-        type: 'previewNode',
-        position: { x: x2, y: l2Y },
-        draggable: false,
-        selectable: false,
-        data: { label: `+${overflowLevel2} more`, isPlaceholder: true },
-      } as Node);
-      previewEdges.push({
-        id: `__preview_edge_${subId}_more`,
-        source: previewId,
-        sourceHandle: 'preview-bottom',
-        target: placeholderId,
-        targetHandle: 'preview-top',
-        type: 'default',
-        style: edgeStyle,
-        animated: false,
-      });
-    }
-  });
-
-  if (overflowLevel1 > 0) {
-    const x = level1StartX + visibleLevel1.length * (PREVIEW_W + PREVIEW_GAP_X);
-    const placeholderId = `__preview_l1_more`;
-    previewNodes.push({
-      id: placeholderId,
-      type: 'previewNode',
-      position: { x, y: level1Y },
-      draggable: false,
-      selectable: false,
-      data: { label: `+${overflowLevel1} more`, isPlaceholder: true },
-    } as Node);
-    previewEdges.push({
-      id: `__preview_edge_${hoveredNode.id}_more`,
-      source: hoveredNode.id,
-      sourceHandle: 'bottom-source',
-      target: placeholderId,
-      targetHandle: 'preview-top',
-      type: 'default',
-      style: edgeStyle,
-      animated: false,
-    });
-  }
-
-  return { nodes: previewNodes, edges: previewEdges };
+  return { nodes: ctx.outNodes, edges: ctx.outEdges };
 }


### PR DESCRIPTION
…ings

The buggy "Vollständige Hierarchie"-Toolbar-Button is removed and the toggle moved to LayoutSettings (default on); switching it triggers a full reset to the initial view via setFullHierarchyAndReset, which uses an explicit override to sidestep stale-closure issues. Overview button now also clears enum/assoc history and toggles, so the separate Reset button is gone — one click returns the user to the initial state.