### PR TITLE
chore(ui): minor magic layout + toolbar tweaks

### DIFF
--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -149,6 +149,7 @@ const Flow: React.FC = () => {
     showAssociations,
     handleToggleAssociations,
     handleMagicLayout,
+    resetCurrentLayout,
     applyLayout,
     fitViewRequest,
     requestFitView,
@@ -758,6 +759,7 @@ const Flow: React.FC = () => {
             exportAnchorEl={exportAnchorEl}
             onBack={handleBack}
             onLineTypeToggle={handleLineTypeToggle}
+            onResetLayout={resetCurrentLayout}
             onMagicLayout={handleMagicLayout}
             onCollapseAll={handleCollapseAll}
             onExpandAll={handleExpandAll}

--- a/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
+++ b/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
@@ -15,6 +15,7 @@ import {
   ExpandLess,
   FileDownload,
   GridView,
+  RestartAlt,
 } from '@mui/icons-material';
 import { useTheme } from '../../../../common/theme/ThemeContext';
 import { CurvedIcon, StraightIcon } from '../../../exp-explorer/components/expIcons';
@@ -29,6 +30,7 @@ interface IliSideToolbarProps {
   onShowOverview: () => void;
   onBack: () => void;
   onLineTypeToggle: () => void;
+  onResetLayout: () => void;
   onMagicLayout: () => void;
   onCollapseAll: () => void;
   onExpandAll: () => void;
@@ -49,6 +51,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
   onShowOverview,
   onBack,
   onLineTypeToggle,
+  onResetLayout,
   onMagicLayout,
   onCollapseAll,
   onExpandAll,
@@ -113,6 +116,19 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
       </Tooltip>
 
       <Divider sx={{ my: 0.5 }} />
+
+      <Tooltip title="Layout zurücksetzen" placement="right">
+        <span>
+          <IconButton
+            size="small"
+            onClick={onResetLayout}
+            disabled={noNode}
+            aria-label="Reset layout"
+          >
+            <RestartAlt fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
 
       <Tooltip title="Magic Layout" placement="right">
         <span>

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -64,6 +64,7 @@ interface UseIliSchemaReturn {
   showAssociations: boolean;
   handleToggleAssociations: (visible: boolean) => void;
   handleMagicLayout: () => void;
+  resetCurrentLayout: () => void;
   applyLayout: (node: IliNode, override?: Partial<LayoutOptions>) => { nodes: IliNode[]; edges: Edge[] };
   computeLayout: (node: IliNode, override?: Partial<LayoutOptions>) => { nodes: IliNode[]; edges: Edge[] };
   fitViewRequest: number;
@@ -695,6 +696,14 @@ export const useIliSchema = (
     }
   }, [activeNodeId, allNodes, applyLayout, navigationHistory, historyIndex]);
 
+  const resetCurrentLayout = useCallback(() => {
+    if (!activeNodeId) return;
+    const targetNode = allNodes.find(n => n.id === activeNodeId) as IliNode | undefined;
+    if (!targetNode) return;
+    applyLayout(targetNode);
+    requestFitView();
+  }, [activeNodeId, allNodes, applyLayout, requestFitView]);
+
   const handleMagicLayout = useCallback(() => {
     if (activeNodeId) {
       const currentNode = allNodes.find(node => node.id === activeNodeId);
@@ -793,6 +802,7 @@ export const useIliSchema = (
     showAssociations,
     handleToggleAssociations,
     handleMagicLayout,
+    resetCurrentLayout,
     applyLayout,
     computeLayout,
     fitViewRequest,

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -129,7 +129,7 @@ export function attachClassAssociations(
   const activeNodeY = entity.position.y;
   const totalAssociations = sortedAssociations.length;
   const spacingY = useMagicLayout
-    ? LAYOUT_CONFIG.ASSOCIATION.SPACING_Y * LAYOUT_CONFIG.MAGIC.MULTIPLIER
+    ? LAYOUT_CONFIG.ASSOCIATION.SPACING_Y * LAYOUT_CONFIG.MAGIC.ASSOCIATION
     : LAYOUT_CONFIG.ASSOCIATION.SPACING_Y;
   const totalHeight = (totalAssociations - 1) * spacingY;
   const startY = activeNodeY - totalHeight / 2;

--- a/src/features/ili-explorer/services/layout/config.ts
+++ b/src/features/ili-explorer/services/layout/config.ts
@@ -22,6 +22,9 @@ export const LAYOUT_CONFIG = {
   },
   MAGIC: {
     GAP: 50,
-    MULTIPLIER: 2.5,
+    SUBTYPE_VERTICAL: 2.7,
+    SUBTYPE_ROW: 3.0,
+    ENUM: 2.5,
+    ASSOCIATION: 2.5,
   },
 } as const;

--- a/src/features/ili-explorer/services/layout/enumStrategy.ts
+++ b/src/features/ili-explorer/services/layout/enumStrategy.ts
@@ -89,7 +89,7 @@ export function attachClassEnums(
 
   const totalEnums = attributes.filter(a => a.isEnum || a.isDomainEnum).length || 0;
   const spacingY = useMagicLayout
-    ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.MULTIPLIER
+    ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.ENUM
     : LAYOUT_CONFIG.ENUM.SPACING_Y;
   const totalHeight = (totalEnums - 1) * spacingY;
   const startY = -(totalHeight / 2);

--- a/src/features/ili-explorer/services/layout/getDirectRelations.ts
+++ b/src/features/ili-explorer/services/layout/getDirectRelations.ts
@@ -171,7 +171,7 @@ export function getDirectRelations(
           const index = enumArray.indexOf(id);
           const totalEnums = enumArray.length;
           const spacingY = useMagicLayout
-            ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.MULTIPLIER
+            ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.ENUM
             : LAYOUT_CONFIG.ENUM.SPACING_Y;
           const totalHeight = (totalEnums - 1) * spacingY;
           const startY = -(totalHeight / 2);

--- a/src/features/ili-explorer/services/layout/positioning.ts
+++ b/src/features/ili-explorer/services/layout/positioning.ts
@@ -11,7 +11,7 @@ export function calculateSubtypePosition(
     const startX = -(totalWidth / 2);
     return {
       x: startX + index * LAYOUT_CONFIG.SPACING.HORIZONTAL,
-      y: LAYOUT_CONFIG.SPACING.VERTICAL * (useMagicLayout ? 2 : 1),
+      y: LAYOUT_CONFIG.SPACING.VERTICAL * (useMagicLayout ? LAYOUT_CONFIG.MAGIC.SUBTYPE_VERTICAL : 1),
     };
   }
 
@@ -27,10 +27,10 @@ export function calculateSubtypePosition(
   const startX = -(rowWidth / 2);
 
   const verticalSpacing = useMagicLayout
-    ? LAYOUT_CONFIG.SPACING.VERTICAL * 2
+    ? LAYOUT_CONFIG.SPACING.VERTICAL * LAYOUT_CONFIG.MAGIC.SUBTYPE_VERTICAL
     : LAYOUT_CONFIG.SPACING.VERTICAL;
   const rowSpacing = useMagicLayout
-    ? LAYOUT_CONFIG.SPACING.ROW * 2
+    ? LAYOUT_CONFIG.SPACING.ROW * LAYOUT_CONFIG.MAGIC.SUBTYPE_ROW
     : LAYOUT_CONFIG.SPACING.ROW;
 
   return {


### PR DESCRIPTION
- Split MAGIC.MULTIPLIER into per-area multipliers (subtype-vertical, subtype-row, enum, association) so each can be tuned individually.
- Bump subtype magic spacing for more breathing room when expanded.
- Add "Layout zurücksetzen" button above Magic Layout in side toolbar.