### PR TITLE
feat(ui): user-pickable active color + hover/preview polish

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -15,8 +15,15 @@ import { Settings as SettingsIcon } from '@mui/icons-material';
 import { useTheme } from '../theme/ThemeContext';
 import { useSettings } from '../settings/SettingsContext';
 
+const ACCENT_PRESETS: { label: string; color: string }[] = [
+  { label: 'Orange', color: '#e65a1a' },
+  { label: 'Lila', color: '#9c27b0' },
+  { label: 'Beton', color: '#6e7378' },
+  { label: 'Haselnuss', color: '#8b5e3c' },
+];
+
 const Settings: React.FC = () => {
-  const { mode, setMode, colorScheme, setColorScheme } = useTheme();
+  const { mode, setMode, colorScheme, setColorScheme, accentColor, setAccentColor } = useTheme();
   const {
     experimentalFeatures, setExperimentalFeatures,
     parserBackend, setParserBackend,
@@ -93,9 +100,9 @@ const Settings: React.FC = () => {
                 </Box>
               }
             />
-            <FormControlLabel 
-              value="highContrast" 
-              control={<Radio size="small" />} 
+            <FormControlLabel
+              value="highContrast"
+              control={<Radio size="small" />}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                   <Box sx={{ width: 16, height: 16, bgcolor: '#000000', borderRadius: 1 }} />
@@ -103,19 +110,57 @@ const Settings: React.FC = () => {
                 </Box>
               }
             />
-            <FormControlLabel
-              value="purple"
-              control={<Radio size="small" />}
-              label={
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Box sx={{ width: 16, height: 16, bgcolor: '#9d18e9', borderRadius: 1 }} />
-                  <Typography variant="body2">Violett</Typography>
-                </Box>
-              }
-            />
           </RadioGroup>
         </MenuItem>
         <Divider />
+        <MenuItem sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Aktiv-Farbe
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            {ACCENT_PRESETS.map(preset => {
+              const selected = accentColor.toLowerCase() === preset.color.toLowerCase();
+              return (
+                <Box
+                  key={preset.color}
+                  onClick={() => setAccentColor(preset.color)}
+                  title={preset.label}
+                  sx={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: '50%',
+                    bgcolor: preset.color,
+                    cursor: 'pointer',
+                    border: '2px solid',
+                    borderColor: selected ? 'text.primary' : 'transparent',
+                    boxShadow: '0 0 0 1px rgba(0,0,0,0.18)',
+                    transition: 'transform 120ms ease',
+                    '&:hover': { transform: 'scale(1.08)' },
+                  }}
+                />
+              );
+            })}
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 0.5 }}>
+              Eigene:
+            </Typography>
+            <Box
+              component="input"
+              type="color"
+              value={accentColor}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAccentColor(e.target.value)}
+              sx={{
+                width: 26,
+                height: 26,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: '50%',
+                cursor: 'pointer',
+                bgcolor: 'transparent',
+                p: 0,
+              }}
+            />
+          </Box>
+        </MenuItem>
         <Divider />
         <MenuItem sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>
           <Typography variant="subtitle2" gutterBottom>

--- a/src/common/settings/SettingsContext.tsx
+++ b/src/common/settings/SettingsContext.tsx
@@ -7,12 +7,15 @@ interface SettingsContextType {
   setExperimentalFeatures: (enabled: boolean) => void;
   parserBackend: ParserBackend;
   setParserBackend: (backend: ParserBackend) => void;
+  tooltipsEnabled: boolean;
+  setTooltipsEnabled: (enabled: boolean) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'experimentalFeatures';
 const PARSER_KEY = 'parserBackend';
+const TOOLTIPS_KEY = 'tooltipsEnabled';
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [experimentalFeatures, setExperimentalFeatures] = useState<boolean>(() => {
@@ -24,6 +27,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return stored === 'legacy' ? 'legacy' : 'ng';
   });
 
+  const [tooltipsEnabled, setTooltipsEnabled] = useState<boolean>(() => {
+    const stored = localStorage.getItem(TOOLTIPS_KEY);
+    return stored === null ? true : stored === 'true';
+  });
+
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, String(experimentalFeatures));
   }, [experimentalFeatures]);
@@ -32,10 +40,16 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(PARSER_KEY, parserBackend);
   }, [parserBackend]);
 
+  useEffect(() => {
+    localStorage.setItem(TOOLTIPS_KEY, String(tooltipsEnabled));
+    document.body.classList.toggle('tooltips-off', !tooltipsEnabled);
+  }, [tooltipsEnabled]);
+
   return (
     <SettingsContext.Provider value={{
       experimentalFeatures, setExperimentalFeatures,
       parserBackend, setParserBackend,
+      tooltipsEnabled, setTooltipsEnabled,
     }}>
       {children}
     </SettingsContext.Provider>

--- a/src/common/theme/ThemeContext.tsx
+++ b/src/common/theme/ThemeContext.tsx
@@ -43,8 +43,13 @@ export interface ThemeContextType {
   setMode: (mode: 'light' | 'dark') => void;
   colorScheme: string;
   setColorScheme: (scheme: string) => void;
+  accentColor: string;
+  setAccentColor: (color: string) => void;
   colors: ThemeColors;
 }
+
+const DEFAULT_ACCENT_COLOR = '#9c27b0';
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
 interface ThemeProviderProps {
   children: ReactNode;
@@ -52,8 +57,10 @@ interface ThemeProviderProps {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const HIDDEN_SCHEMES = new Set(['purple']);
+
 function normalizeColorScheme(scheme: string | null): string {
-  if (!scheme || !colorSchemes[scheme]) {
+  if (!scheme || !colorSchemes[scheme] || HIDDEN_SCHEMES.has(scheme)) {
     return 'default';
   }
   return scheme;
@@ -273,6 +280,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     return normalized;
   });
 
+  const [accentColor, setAccentColor] = useState<string>(() => {
+    const saved = localStorage.getItem('accentColor');
+    return saved && HEX_COLOR_RE.test(saved) ? saved : DEFAULT_ACCENT_COLOR;
+  });
+
   useEffect(() => {
     localStorage.setItem('themeMode', mode);
   }, [mode]);
@@ -280,6 +292,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   useEffect(() => {
     localStorage.setItem('colorScheme', colorScheme);
   }, [colorScheme]);
+
+  useEffect(() => {
+    localStorage.setItem('accentColor', accentColor);
+  }, [accentColor]);
 
   const processColorValue = useCallback((value: any): string => {
     if (typeof value === 'function') {
@@ -291,7 +307,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const colors = useMemo(() => {
     const schemeKey = colorSchemes[colorScheme] ? colorScheme : 'default';
     const scheme = colorSchemes[schemeKey];
-    return Object.keys(scheme).reduce<Partial<ThemeColors>>((acc, key) => {
+    const resolved = Object.keys(scheme).reduce<Partial<ThemeColors>>((acc, key) => {
       const value = scheme[key];
       if (typeof value === 'object' && value !== null) {
         acc[key as keyof ThemeColors] = Object.keys(value).reduce((subAcc: any, subKey) => {
@@ -303,13 +319,17 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       }
       return acc;
     }, {}) as ThemeColors;
-  }, [colorScheme, processColorValue]);
+    resolved.selectedEntity = accentColor;
+    return resolved;
+  }, [colorScheme, processColorValue, accentColor]);
 
   const value = {
     mode,
     setMode,
     colorScheme,
     setColorScheme,
+    accentColor,
+    setAccentColor,
     colors
   };
 

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -104,6 +104,12 @@ const globalStyles = `
   .noclick {
     pointer-events: none;
   }
+  .react-flow__edge.animated path.react-flow__edge-path {
+    animation-duration: 1s;
+  }
+  body.tooltips-off .MuiTooltip-popper {
+    display: none !important;
+  }
 `;
 
 const Flow: React.FC = () => {
@@ -379,45 +385,71 @@ const Flow: React.FC = () => {
   , [nodes, handleNodeExpand]);
 
   const [hoveredClassId, setHoveredClassId] = useState<string | null>(null);
+  const [tintHoverId, setTintHoverId] = useState<string | null>(null);
   const [hoverPreviewEnabled, setHoverPreviewEnabled] = useState(true);
+  const previewDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const PREVIEW_DELAY_MS = 500;
 
-  // Beim Drill-In aus der Overview behält React den hovered-State, bis die
-  // Maus das nächste Mal bewegt wird — das Preview blitzt sonst kurz auf der
-  // neu aktiven Klasse auf. Darum bei jedem Wechsel der aktiven Klasse cleanen.
   useEffect(() => {
     setHoveredClassId(null);
+    setTintHoverId(null);
+    if (previewDelayRef.current) {
+      clearTimeout(previewDelayRef.current);
+      previewDelayRef.current = null;
+    }
   }, [activeNodeId]);
 
-  // Walk up the EXTENDS chain from the active class — every ancestor (direct
-  // parent, grandparent, …) is already represented in the current view, so
-  // hover preview on any of them would duplicate what's visible.
-  const activeSupertypeIds = useMemo(() => {
-    if (!activeNodeId) return new Set<string>();
-    const seen = new Set<string>();
+  const ancestorDepth = useMemo(() => {
+    const depths = new Map<string, number>();
+    if (!activeNodeId) return depths;
+    depths.set(activeNodeId, 0);
     const queue: string[] = [activeNodeId];
     while (queue.length > 0) {
       const id = queue.shift()!;
+      const d = depths.get(id)!;
       for (const e of allEdges) {
-        if (e.source === id && !seen.has(e.target)) {
-          seen.add(e.target);
+        if (e.source === id && !depths.has(e.target)) {
+          depths.set(e.target, d + 1);
           queue.push(e.target);
         }
       }
     }
-    return seen;
+    return depths;
   }, [activeNodeId, allEdges]);
 
+  const activeSupertypeIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const [id, d] of ancestorDepth) {
+      if (d > 0) set.add(id);
+    }
+    return set;
+  }, [ancestorDepth]);
+
   const handleNodeMouseEnter = useCallback((_e: React.MouseEvent, node: ReactFlowNode) => {
+    const tintableTypes = new Set(['classNode', 'enumNode', 'domainEnumNode', 'associationNode']);
+    if (!tintableTypes.has(node.type ?? '')) return;
+    if (node.id === activeNodeId) return;
+    setTintHoverId(node.id);
+
     if (!hoverPreviewEnabled) return;
     if (node.type !== 'classNode') return;
-    if (node.id === activeNodeId) return;
     if (activeSupertypeIds.has(node.id)) return;
     if ((node.data as { expanded?: boolean } | undefined)?.expanded) return;
-    setHoveredClassId(node.id);
+
+    if (previewDelayRef.current) clearTimeout(previewDelayRef.current);
+    previewDelayRef.current = setTimeout(() => {
+      setHoveredClassId(node.id);
+      previewDelayRef.current = null;
+    }, PREVIEW_DELAY_MS);
   }, [hoverPreviewEnabled, activeNodeId, activeSupertypeIds]);
 
   const handleNodeMouseLeave = useCallback(() => {
+    if (previewDelayRef.current) {
+      clearTimeout(previewDelayRef.current);
+      previewDelayRef.current = null;
+    }
     setHoveredClassId(null);
+    setTintHoverId(null);
   }, []);
 
   const hoverPreview = useMemo(() => {
@@ -439,10 +471,53 @@ const Flow: React.FC = () => {
     () => [...nodesWithHandlers, ...hoverPreview.nodes],
     [nodesWithHandlers, hoverPreview.nodes]
   );
-  const renderedEdges = useMemo(
-    () => [...edges, ...hoverPreview.edges],
-    [edges, hoverPreview.edges]
-  );
+  // Pick the single edge from the hovered node to its closest neighbour in the
+  // active-class hierarchy. For ancestors that's the direct child (one rank
+  // closer to active); for subtypes / enums / assocs it's active itself.
+  const tintedEdgeId = useMemo(() => {
+    if (!tintHoverId || !activeNodeId) return null;
+    let bestId: string | null = null;
+    let bestDepth = Infinity;
+    for (const e of edges) {
+      let other: string | null = null;
+      if (e.source === tintHoverId) other = e.target;
+      else if (e.target === tintHoverId) other = e.source;
+      if (other === null) continue;
+      const d = ancestorDepth.get(other);
+      if (d === undefined) continue;
+      if (d < bestDepth) {
+        bestDepth = d;
+        bestId = e.id;
+      }
+    }
+    return bestId;
+  }, [tintHoverId, activeNodeId, edges, ancestorDepth]);
+
+  const renderedEdges = useMemo(() => {
+    const strokeFade = 'stroke 1.4s ease-out';
+    const withFade = edges.map(e => ({
+      ...e,
+      style: { ...e.style, transition: strokeFade },
+    }));
+    const tinted = tintedEdgeId
+      ? withFade.map(e => {
+          if (e.id !== tintedEdgeId) return e;
+          const tintedMarkerEnd = e.markerEnd && typeof e.markerEnd === 'object'
+            ? { ...e.markerEnd, color: colors.selectedEntity }
+            : e.markerEnd;
+          return {
+            ...e,
+            style: {
+              ...e.style,
+              stroke: colors.selectedEntity,
+              transition: strokeFade,
+            },
+            markerEnd: tintedMarkerEnd,
+          };
+        })
+      : withFade;
+    return [...tinted, ...hoverPreview.edges];
+  }, [edges, hoverPreview.edges, tintedEdgeId, colors.selectedEntity]);
 
  
   const debouncedHandleMaxSubTypesChange = useCallback(

--- a/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
@@ -98,8 +98,19 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
         overflow: 'hidden',
         bgcolor: data.isActive ? colors.selectedNodeBg : colors.nodeContent,
         color: colors.text,
+        transition: 'box-shadow 0.2s ease-in-out, background-color 1400ms ease-out, border-color 1400ms ease-out',
+        '& .ili-node-header': {
+          transition: 'background-color 1400ms ease-out',
+        },
         '&:hover': {
-          boxShadow: colors.shadow
+          boxShadow: colors.shadow,
+          ...(data.isActive ? {} : {
+            ...(expanded ? {} : { bgcolor: alpha(colors.selectedEntity, 0.18) }),
+            borderColor: colors.selectedEntity,
+            '& .ili-node-header': {
+              bgcolor: colors.selectedEntity,
+            },
+          }),
         }
       }}
     >
@@ -155,11 +166,11 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
           }
         }}
       >
-        <Box sx={{ 
+        <Box className="ili-node-header" sx={{
           bgcolor: data.isActive || data.isHighlighted
-            ? colors.selectedEntity 
-            : data.isSource 
-              ? alpha(colors.relationship, 0.8) 
+            ? colors.selectedEntity
+            : data.isSource
+              ? alpha(colors.relationship, 0.8)
               : alpha(colors.relationship, 0.5),
           p: 1,
           textAlign: 'center',
@@ -238,9 +249,9 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
                 }
               }}
             >
-              <Box sx={{ 
+              <Box sx={{
                 display: 'grid',
-                gridTemplateColumns: '1fr auto',
+                gridTemplateColumns: 'minmax(0, 1fr) max-content',
                 gap: 2,
                 alignItems: 'start'
               }}>
@@ -267,12 +278,12 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
                   )}
                 </Box>
                 {data.association.sourceCardinality && (
-                  <Typography 
-                    variant="body2" 
+                  <Typography
+                    variant="body2"
                     color={colors.propertyText}
-                    sx={{ 
+                    sx={{
                       fontFamily: 'monospace',
-                      minWidth: '60px',
+                      whiteSpace: 'nowrap',
                       textAlign: 'right',
                       bgcolor: alpha(colors.primary, 0.1),
                       px: 1,
@@ -322,9 +333,9 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
                 }
               }}
             >
-              <Box sx={{ 
+              <Box sx={{
                 display: 'grid',
-                gridTemplateColumns: '1fr auto',
+                gridTemplateColumns: 'minmax(0, 1fr) max-content',
                 gap: 2,
                 alignItems: 'start'
               }}>
@@ -351,12 +362,12 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
                   )}
                 </Box>
                 {data.association.targetCardinality && (
-                  <Typography 
-                    variant="body2" 
+                  <Typography
+                    variant="body2"
                     color={colors.propertyText}
-                    sx={{ 
+                    sx={{
                       fontFamily: 'monospace',
-                      minWidth: '60px',
+                      whiteSpace: 'nowrap',
                       textAlign: 'right',
                       bgcolor: alpha(colors.primary, 0.1),
                       px: 1,

--- a/src/features/ili-explorer/components/nodes/IliClassNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliClassNode.tsx
@@ -348,9 +348,19 @@ export const IliClassNode = memo<IliClassNodeProps>(({ data }) => {
           overflow: 'hidden',
           bgcolor: data.isActive ? colors.selectedNodeBg : colors.nodeContent,
           color: colors.text,
-          transition: 'box-shadow 0.2s ease-in-out',
+          transition: 'box-shadow 0.2s ease-in-out, background-color 1400ms ease-out, border-color 1400ms ease-out',
+          '& .ili-class-header': {
+            transition: 'background-color 1400ms ease-out',
+          },
           '&:hover': {
-            boxShadow: theme => theme.shadows[8]
+            boxShadow: theme => theme.shadows[8],
+            ...(data.isActive ? {} : {
+              ...(data.expanded ? {} : { bgcolor: alpha(colors.selectedEntity, 0.18) }),
+              borderColor: colors.selectedEntity,
+              '& .ili-class-header': {
+                bgcolor: colors.selectedEntity,
+              },
+            }),
           }
         }}
       >
@@ -415,11 +425,11 @@ export const IliClassNode = memo<IliClassNodeProps>(({ data }) => {
             }
           }}
         >
-          <Box sx={{ 
-            bgcolor: data.isHighlighted 
-              ? colors.selectedEntity 
+          <Box className="ili-class-header" sx={{
+            bgcolor: data.isHighlighted
+              ? colors.selectedEntity
               : data.isAbstract
-                ? colors.abstractEntity 
+                ? colors.abstractEntity
                 : colors.inheritance,
             p: 1,
             textAlign: 'center',

--- a/src/features/ili-explorer/components/nodes/IliDomainEnumNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliDomainEnumNode.tsx
@@ -174,8 +174,19 @@ export const IliDomainEnumNode: React.FC<IliDomainEnumNodeProps> = memo(({ data 
         overflow: 'hidden',
         bgcolor: data.isActive ? colors.selectedNodeBg : colors.nodeContent,
         color: colors.text,
+        transition: 'box-shadow 0.2s ease-in-out, background-color 1400ms ease-out, border-color 1400ms ease-out',
+        '& .ili-node-header': {
+          transition: 'background-color 1400ms ease-out',
+        },
         '&:hover': {
-          boxShadow: colors.shadow
+          boxShadow: colors.shadow,
+          ...(data.isActive ? {} : {
+            ...(data.expanded ? {} : { bgcolor: alpha(colors.selectedEntity, 0.18) }),
+            borderColor: colors.selectedEntity,
+            '& .ili-node-header': {
+              bgcolor: colors.selectedEntity,
+            },
+          }),
         }
       }}
     >
@@ -198,9 +209,9 @@ export const IliDomainEnumNode: React.FC<IliDomainEnumNodeProps> = memo(({ data 
       <Handle type="source" position={Position.Top} id="top" style={{ opacity: 0 }} />
       <Handle type="target" position={Position.Bottom} id="bottom" style={{ opacity: 0 }} />
 
-      <Box sx={{
-        bgcolor: data.isHighlighted 
-          ? colors.selectedEntity 
+      <Box className="ili-node-header" sx={{
+        bgcolor: data.isHighlighted
+          ? colors.selectedEntity
           : alpha(colors.typeNode, 0.8),
         p: 1,
         textAlign: 'center',

--- a/src/features/ili-explorer/components/nodes/IliEnumNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliEnumNode.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip
 } from '@mui/material';
 import { ExpandMore, ExpandLess, ChevronRight } from '@mui/icons-material';
+import { alpha } from '@mui/material/styles';
 import { useTheme } from '../../../../common/theme/ThemeContext';
 import { ResizeHandle } from './ResizeHandle';
 
@@ -198,8 +199,19 @@ export const IliEnumNode: React.FC<IliEnumNodeProps> = memo(({ data }) => {
         overflow: 'hidden',
         bgcolor: data.isActive ? colors.selectedNodeBg : colors.nodeContent,
         color: colors.text,
+        transition: 'box-shadow 0.2s ease-in-out, background-color 1400ms ease-out, border-color 1400ms ease-out',
+        '& .ili-node-header': {
+          transition: 'background-color 1400ms ease-out',
+        },
         '&:hover': {
-          boxShadow: colors.shadow
+          boxShadow: colors.shadow,
+          ...(data.isActive ? {} : {
+            ...(data.expanded ? {} : { bgcolor: alpha(colors.selectedEntity, 0.18) }),
+            borderColor: colors.selectedEntity,
+            '& .ili-node-header': {
+              bgcolor: colors.selectedEntity,
+            },
+          }),
         }
       }}
     >
@@ -258,7 +270,7 @@ export const IliEnumNode: React.FC<IliEnumNodeProps> = memo(({ data }) => {
           }
         }}
       >
-        <Box sx={{ 
+        <Box className="ili-node-header" sx={{
           bgcolor: data.isHighlighted ? colors.selectedEntity : colors.typeNode,
           p: 1,
           textAlign: 'center',

--- a/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliPreviewNode.tsx
@@ -19,7 +19,7 @@ export const IliPreviewNode: React.FC<IliPreviewNodeProps> = memo(({ data }) => 
         px: 1.25,
         py: 0.5,
         borderRadius: 0.5,
-        border: '1px solid #555',
+        border: `1px solid ${colors.selectedEntity}`,
         bgcolor: 'background.paper',
         color: colors.text,
         pointerEvents: 'none',

--- a/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
+++ b/src/features/ili-explorer/components/sidebar/LayoutSettings.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { Settings } from '@mui/icons-material';
 import { useTheme } from '../../../../common/theme/ThemeContext';
+import { useSettings } from '../../../../common/settings/SettingsContext';
 
 interface LayoutSettingsProps {
   maxSubTypesPerRow: number;
@@ -31,7 +32,8 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
   fullHierarchy,
   onFullHierarchyChange,
 }) => {
-  const { colors } = useTheme();
+  useTheme();
+  const { tooltipsEnabled, setTooltipsEnabled } = useSettings();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [limitSubTypes, setLimitSubTypes] = useState(true);
   const [textFieldValue, setTextFieldValue] = useState('4');
@@ -226,8 +228,24 @@ export const LayoutSettings: React.FC<LayoutSettingsProps> = ({
               Beim Umschalten wird die Ansicht zurückgesetzt.
             </Typography>
           </Box>
+
+          <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={tooltipsEnabled}
+                  onChange={(e) => setTooltipsEnabled(e.target.checked)}
+                  size="small"
+                />
+              }
+              label="Tooltips anzeigen"
+            />
+            <Typography variant="caption" sx={{ display: 'block', mt: 0.5, opacity: 0.7 }}>
+              Hinweis-Bubbles bei Klassen, Attributen und Aufzählungen.
+            </Typography>
+          </Box>
         </Box>
       </Popover>
     </Paper>
   );
-}; 
+};

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -75,7 +75,7 @@ export function layoutAssociationCenter(
       source: sourceId,
       target: entity.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: false,
+      animated: true,
       sourceHandle: 'right-source',
       targetHandle: 'left-target',
       style: {
@@ -92,7 +92,7 @@ export function layoutAssociationCenter(
       source: entity.id,
       target: targetClass.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: false,
+      animated: true,
       sourceHandle: 'right-source',
       targetHandle: 'left-target',
       style: {
@@ -163,7 +163,7 @@ export function attachClassAssociations(
       source: isSource ? entity.id : associationNodeId,
       target: isSource ? associationNodeId : entity.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: false,
+      animated: true,
       sourceHandle: isSource ? 'left-source' : 'right-source',
       targetHandle: isSource ? 'right-target' : 'left-target',
       style: {

--- a/src/features/ili-explorer/services/layout/previewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/previewStrategy.ts
@@ -164,14 +164,13 @@ export function layoutHoverPreview(
   const startX = hCenterX + TRUNK_TO_BOX_GAP;
   const startY = hBottomY + FIRST_OFFSET_Y;
 
-  const lineColor = '#555';
+  const lineColor = colors.selectedEntity;
   const ctx: LayoutCtx = {
     nodeById: new Map(allNodes.map(n => [n.id, n])),
     inheritanceEdges,
     edgeStyle: {
       stroke: lineColor,
       strokeWidth: 1,
-      opacity: 0.9,
     },
     markerEnd: {
       type: MarkerType.ArrowClosed,
@@ -182,9 +181,6 @@ export function layoutHoverPreview(
     outNodes: [],
     outEdges: [],
   };
-  // colors is intentionally unused now that the preview uses a fixed dark
-  // grey — keep the parameter to preserve the call signature for callers.
-  void colors;
 
   layoutChildren(
     ctx,


### PR DESCRIPTION
- Active-color picker (4 presets + custom) in Settings; replaces the violet scheme. Drives selectedEntity everywhere (active, hover, preview).
- Tooltips can now be toggled globally via LayoutSettings (CSS class on body, no prop drilling through every node type).
- Hover preview: 500ms delay matching tooltip behaviour, box fade removed.