### PR TITLE
refactor(ili-explorer): split useIliSchema, drop legacy parser, fix a…

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -26,7 +26,6 @@ const Settings: React.FC = () => {
   const { mode, setMode, colorScheme, setColorScheme, accentColor, setAccentColor } = useTheme();
   const {
     experimentalFeatures, setExperimentalFeatures,
-    parserBackend, setParserBackend,
   } = useSettings();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
@@ -160,30 +159,6 @@ const Settings: React.FC = () => {
               }}
             />
           </Box>
-        </MenuItem>
-        <Divider />
-        <MenuItem sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>
-          <Typography variant="subtitle2" gutterBottom>
-            Parser-Backend (ILI-Explorer)
-          </Typography>
-          <RadioGroup
-            value={parserBackend}
-            onChange={(e) => setParserBackend(e.target.value as 'legacy' | 'ng')}
-          >
-            <FormControlLabel
-              value="ng"
-              control={<Radio size="small" />}
-              label={<Typography variant="body2">Chevrotain (Standard)</Typography>}
-            />
-            <FormControlLabel
-              value="legacy"
-              control={<Radio size="small" />}
-              label={<Typography variant="body2">Legacy Regex (Old)</Typography>}
-            />
-          </RadioGroup>
-          <Typography variant="caption" sx={{ color: 'text.secondary', mt: 0.5 }}>
-            Modell neu laden, damit der Wechsel greift.
-          </Typography>
         </MenuItem>
         <Divider />
         <MenuItem>

--- a/src/common/settings/SettingsContext.tsx
+++ b/src/common/settings/SettingsContext.tsx
@@ -1,12 +1,8 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
-export type ParserBackend = 'legacy' | 'ng';
-
 interface SettingsContextType {
   experimentalFeatures: boolean;
   setExperimentalFeatures: (enabled: boolean) => void;
-  parserBackend: ParserBackend;
-  setParserBackend: (backend: ParserBackend) => void;
   tooltipsEnabled: boolean;
   setTooltipsEnabled: (enabled: boolean) => void;
 }
@@ -14,17 +10,11 @@ interface SettingsContextType {
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'experimentalFeatures';
-const PARSER_KEY = 'parserBackend';
 const TOOLTIPS_KEY = 'tooltipsEnabled';
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [experimentalFeatures, setExperimentalFeatures] = useState<boolean>(() => {
     return localStorage.getItem(STORAGE_KEY) === 'true';
-  });
-
-  const [parserBackend, setParserBackend] = useState<ParserBackend>(() => {
-    const stored = localStorage.getItem(PARSER_KEY);
-    return stored === 'legacy' ? 'legacy' : 'ng';
   });
 
   const [tooltipsEnabled, setTooltipsEnabled] = useState<boolean>(() => {
@@ -37,10 +27,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [experimentalFeatures]);
 
   useEffect(() => {
-    localStorage.setItem(PARSER_KEY, parserBackend);
-  }, [parserBackend]);
-
-  useEffect(() => {
     localStorage.setItem(TOOLTIPS_KEY, String(tooltipsEnabled));
     document.body.classList.toggle('tooltips-off', !tooltipsEnabled);
   }, [tooltipsEnabled]);
@@ -48,7 +34,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   return (
     <SettingsContext.Provider value={{
       experimentalFeatures, setExperimentalFeatures,
-      parserBackend, setParserBackend,
       tooltipsEnabled, setTooltipsEnabled,
     }}>
       {children}

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -112,7 +112,7 @@ const globalStyles = `
 `;
 
 const Flow: React.FC = () => {
-  const { fitView, getViewport } = useReactFlow();
+  const { fitView } = useReactFlow();
   const { colors, mode } = useTheme();
   const [useCurvedLines, setUseCurvedLines] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -157,14 +157,14 @@ const Flow: React.FC = () => {
     handleToggleAssociations,
     handleMagicLayout,
     resetCurrentLayout,
-    applyLayout,
+    handleMaxSubTypesChange,
     fitViewRequest,
   } = useIliSchema(
-    setNodes, 
-    setEdges, 
-    useCurvedLines, 
-    setUseCurvedLines,
-    fitView
+    nodes,
+    setNodes,
+    setEdges,
+    useCurvedLines,
+    setUseCurvedLines
   );
 
   const handleFileUpload = useCallback((file: File) => {
@@ -234,19 +234,8 @@ const Flow: React.FC = () => {
       }
     };
 
-    const currentViewport = getViewport();
-    baseHandleNodeClick(event, iliNode, currentViewport);
-  }, [activeNodeId, baseHandleNodeClick, getViewport]);
-
-  const handleMaxSubTypesChange = useCallback((value: number) => {
-    setMaxSubTypesPerRow(value);
-    if (activeNodeId) {
-      const currentNode = allNodes.find(n => n.id === activeNodeId);
-      if (currentNode) {
-        applyLayout(currentNode as IliNode, { maxSubTypesPerRow: value });
-      }
-    }
-  }, [activeNodeId, allNodes, applyLayout, setMaxSubTypesPerRow]);
+    baseHandleNodeClick(event, iliNode);
+  }, [activeNodeId, baseHandleNodeClick]);
 
   const controlsStyle = useMemo(() => ({
     backgroundColor: colors.paper,
@@ -260,20 +249,6 @@ const Flow: React.FC = () => {
       }
     }
   }), [colors]);
-
-  const applyLayoutRef = useRef(applyLayout);
-  useEffect(() => {
-    applyLayoutRef.current = applyLayout;
-  });
-
-  useEffect(() => {
-    if (activeNodeId && allNodes.length > 0) {
-      const currentNode = allNodes.find(node => node.id === activeNodeId);
-      if (currentNode) {
-        applyLayoutRef.current(currentNode as IliNode);
-      }
-    }
-  }, [maxSubTypesPerRow, activeNodeId, allNodes]);
 
   const handleSearchSelect = useCallback((selectedNode: SearchOption) => {
     if (selectedNode) {
@@ -463,17 +438,9 @@ const Flow: React.FC = () => {
   }, [edges, hoverPreview.edges, tintedEdgeId, colors.selectedEntity]);
 
  
-  const debouncedHandleMaxSubTypesChange = useCallback(
-    debounce((value: number) => {
-      setMaxSubTypesPerRow(value);
-      if (activeNodeId) {
-        const currentNode = allNodes.find(n => n.id === activeNodeId);
-        if (currentNode) {
-          applyLayout(currentNode as IliNode, { maxSubTypesPerRow: value });
-        }
-      }
-    }, 150),
-    [activeNodeId, allNodes, applyLayout, setMaxSubTypesPerRow]
+  const debouncedHandleMaxSubTypesChange = useMemo(
+    () => debounce((value: number) => handleMaxSubTypesChange(value), 150),
+    [handleMaxSubTypesChange]
   );
 
 

--- a/src/features/ili-explorer/hooks/useDisplayToggles.ts
+++ b/src/features/ili-explorer/hooks/useDisplayToggles.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react';
+
+export interface UseDisplayTogglesReturn {
+  showFullHierarchy: boolean;
+  setShowFullHierarchy: (v: boolean) => void;
+  showEnums: boolean;
+  setShowEnums: (v: boolean) => void;
+  showAssociations: boolean;
+  setShowAssociations: (v: boolean) => void;
+  maxSubTypesPerRow: number;
+  setMaxSubTypesPerRow: (v: number) => void;
+  resetVisibility: () => void;
+}
+
+const DEFAULT_MAX_SUBTYPES_PER_ROW = 4;
+
+export function useDisplayToggles(): UseDisplayTogglesReturn {
+  const [showFullHierarchy, setShowFullHierarchy] = useState(true);
+  const [showEnums, setShowEnums] = useState(true);
+  const [showAssociations, setShowAssociations] = useState(true);
+  const [maxSubTypesPerRow, setMaxSubTypesPerRow] = useState<number>(DEFAULT_MAX_SUBTYPES_PER_ROW);
+
+  const resetVisibility = useCallback(() => {
+    setShowEnums(true);
+    setShowAssociations(true);
+    setMaxSubTypesPerRow(DEFAULT_MAX_SUBTYPES_PER_ROW);
+  }, []);
+
+  return {
+    showFullHierarchy,
+    setShowFullHierarchy,
+    showEnums,
+    setShowEnums,
+    showAssociations,
+    setShowAssociations,
+    maxSubTypesPerRow,
+    setMaxSubTypesPerRow,
+    resetVisibility,
+  };
+}

--- a/src/features/ili-explorer/hooks/useIliLoader.ts
+++ b/src/features/ili-explorer/hooks/useIliLoader.ts
@@ -1,0 +1,140 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Node, Edge } from '@xyflow/react';
+import type { ThemeColors } from '../../../common/theme/ThemeContext';
+import { readFileAsText } from '../../../common/utils/readFileAsText';
+import { IliSchemaService } from '../services/iliSchemaService';
+import { NgIliParser } from '../services/parsers/ng/NgIliParser';
+import { generateSearchOptions } from '../services/searchOptions';
+import { flowNodeFromBaseNode, inheritanceEdgesFromRelations } from '../services/flowMapping';
+import type { IliRelation, SearchOption } from '../services/types/IliBaseTypes';
+import type { IliParseError, IliImportRef } from '../services/parsers/IliParser';
+
+export interface LoadResult {
+  flowNodes: Node[];
+  flowEdges: Edge[];
+  relations: IliRelation[];
+  fileName: string;
+}
+
+interface UseIliLoaderOptions {
+  colors: ThemeColors;
+  useCurvedLines: boolean;
+  onLoaded: (result: LoadResult) => void;
+}
+
+export interface UseIliLoaderReturn {
+  isLoading: boolean;
+  error: string | null;
+  parseWarnings: IliParseError[];
+  dismissParseWarnings: () => void;
+  imports: IliImportRef[];
+  interlisVersion: string | undefined;
+  currentFileName: string | null;
+  allNodes: Node[];
+  allEdges: Edge[];
+  relations: IliRelation[];
+  searchOptions: SearchOption[];
+  loadFromFile: (file: File) => Promise<void>;
+  clear: () => void;
+}
+
+export function useIliLoader(options: UseIliLoaderOptions): UseIliLoaderReturn {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [parseWarnings, setParseWarnings] = useState<IliParseError[]>([]);
+  const [imports, setImports] = useState<IliImportRef[]>([]);
+  const [interlisVersion, setInterlisVersion] = useState<string | undefined>(undefined);
+  const [currentFileName, setCurrentFileName] = useState<string | null>(null);
+  const [allNodes, setAllNodes] = useState<Node[]>([]);
+  const [allEdges, setAllEdges] = useState<Edge[]>([]);
+  const [relations, setRelations] = useState<IliRelation[]>([]);
+  const [searchOptions, setSearchOptions] = useState<SearchOption[]>([]);
+
+  const schemaServiceRef = useRef<IliSchemaService>(new IliSchemaService(new NgIliParser()));
+  const lastContentRef = useRef<{ content: string; fileName: string } | null>(null);
+
+  const colorsRef = useRef(options.colors);
+  const useCurvedLinesRef = useRef(options.useCurvedLines);
+  const onLoadedRef = useRef(options.onLoaded);
+  useEffect(() => {
+    colorsRef.current = options.colors;
+    useCurvedLinesRef.current = options.useCurvedLines;
+    onLoadedRef.current = options.onLoaded;
+  });
+
+  const dismissParseWarnings = useCallback(() => setParseWarnings([]), []);
+
+  const loadFromContent = useCallback(async (content: string, fileName: string) => {
+    try {
+      setError(null);
+      setIsLoading(true);
+      setCurrentFileName(fileName);
+
+      lastContentRef.current = { content, fileName };
+      schemaServiceRef.current.parseSchema(content);
+
+      const baseNodes = schemaServiceRef.current.getNodes();
+      const parsedRelations = schemaServiceRef.current.getRelations();
+      const flowNodes = baseNodes.map(flowNodeFromBaseNode);
+      const flowEdges = inheritanceEdgesFromRelations(
+        parsedRelations,
+        colorsRef.current,
+        useCurvedLinesRef.current
+      );
+
+      setParseWarnings(schemaServiceRef.current.getParseErrors());
+      setImports(schemaServiceRef.current.getImports());
+      setInterlisVersion(schemaServiceRef.current.getInterlisVersion());
+      setAllNodes(flowNodes);
+      setAllEdges(flowEdges);
+      setRelations(parsedRelations);
+      setSearchOptions(generateSearchOptions(baseNodes));
+
+      onLoadedRef.current({
+        flowNodes,
+        flowEdges,
+        relations: parsedRelations,
+        fileName,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fehler beim Laden des Schemas');
+      setCurrentFileName(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const loadFromFile = useCallback(async (file: File) => {
+    const content = await readFileAsText(file);
+    await loadFromContent(content, file.name);
+  }, [loadFromContent]);
+
+  const clear = useCallback(() => {
+    setError(null);
+    setParseWarnings([]);
+    setImports([]);
+    setInterlisVersion(undefined);
+    setCurrentFileName(null);
+    setAllNodes([]);
+    setAllEdges([]);
+    setRelations([]);
+    setSearchOptions([]);
+    lastContentRef.current = null;
+  }, []);
+
+  return {
+    isLoading,
+    error,
+    parseWarnings,
+    dismissParseWarnings,
+    imports,
+    interlisVersion,
+    currentFileName,
+    allNodes,
+    allEdges,
+    relations,
+    searchOptions,
+    loadFromFile,
+    clear,
+  };
+}

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -1,28 +1,18 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import { Node, Edge, Connection, FitViewOptions } from '@xyflow/react';
+import { Node, Edge, Connection } from '@xyflow/react';
 import { useTheme } from '../../../common/theme/ThemeContext';
-import { useSettings } from '../../../common/settings/SettingsContext';
-import { readFileAsText } from '../../../common/utils/readFileAsText';
-import { IliSchemaService } from '../services/iliSchemaService';
-import { LegacyIliParser } from '../services/parsers/LegacyIliParser';
-import { NgIliParser } from '../services/parsers/ng/NgIliParser';
 import { IliLayoutService } from '../services/IliLayoutService';
 import { isOverviewCandidate, layoutModelOverview } from '../services/layout/overviewStrategy';
-import { generateSearchOptions } from '../services/searchOptions';
+import { useNavigationHistory } from './useNavigationHistory';
+import { useIliLoader, type LoadResult } from './useIliLoader';
+import { useDisplayToggles } from './useDisplayToggles';
 import {
-  flowNodeFromBaseNode,
-  inheritanceEdgesFromRelations,
-} from '../services/flowMapping';
-import {
-  IliBaseNode,
-  IliRelation,
   IliNode,
   SearchOption,
   NavigationState,
   LayoutOptions,
 } from '../services/types/IliBaseTypes';
-import { IliClassNode } from '../services/types/IliModelTypes';
 import type { IliParseError, IliImportRef } from '../services/parsers/IliParser';
 
 export type { SearchOption };
@@ -42,7 +32,7 @@ interface UseIliSchemaReturn {
   handleFileUpload: (file: File) => Promise<void>;
   handleClearFile: () => void;
   handleConnect: (params: Connection) => void;
-  handleNodeClick: (event: React.MouseEvent, node: Node, viewport: ViewportState) => void;
+  handleNodeClick: (event: React.MouseEvent, node: Node) => void;
   navigateToNode: (nodeId: string) => boolean;
   handleBack: () => boolean;
   handleForward: () => boolean;
@@ -61,14 +51,11 @@ interface UseIliSchemaReturn {
   maxSubTypesPerRow: number;
   setMaxSubTypesPerRow: (value: number) => void;
   handleLineTypeToggle: () => void;
-  currentNodes: Node[];
-  currentEdges: Edge[];
   showAssociations: boolean;
   handleToggleAssociations: (visible: boolean) => void;
   handleMagicLayout: () => void;
   resetCurrentLayout: () => void;
-  applyLayout: (node: IliNode, override?: Partial<LayoutOptions>) => { nodes: IliNode[]; edges: Edge[] };
-  computeLayout: (node: IliNode, override?: Partial<LayoutOptions>) => { nodes: IliNode[]; edges: Edge[] };
+  handleMaxSubTypesChange: (value: number) => void;
   fitViewRequest: number;
   requestFitView: () => void;
   canGoBack: boolean;
@@ -76,91 +63,104 @@ interface UseIliSchemaReturn {
   showOverview: () => void;
 }
 
-const NAV_HISTORY_LIMIT = 50;
+type DisplayTarget =
+  | { kind: 'overview' }
+  | { kind: 'node'; node: IliNode; override?: Partial<LayoutOptions> };
 
-interface NavStack {
-  entries: NavigationState[];
-  index: number;
+function normalizeIliNode(source: Node | IliNode, extraData?: Record<string, unknown>): IliNode {
+  return {
+    ...source,
+    type: source.type || 'classNode',
+    position: source.position,
+    data: {
+      ...source.data,
+      isHighlighted: false,
+      isActive: false,
+      expanded: source.data?.expanded ?? false,
+      ...extraData,
+    },
+  } as IliNode;
 }
 
-
-interface NodeState {
-  nodes: Node[];
-  edges: Edge[];
-  searchOptions: SearchOption[];
+interface CapturedNodeState {
+  position: { x: number; y: number };
+  expanded: boolean | undefined;
+  isExpanded: boolean | undefined;
+  onExpandChange: ((expanded: boolean) => void) | undefined;
 }
 
-
-interface ViewportState {
-  x: number;
-  y: number;
-  zoom: number;
+function captureNodeStates(source: IliNode[]): Map<string, CapturedNodeState> {
+  return new Map(
+    source.map(n => [n.id, {
+      position: { ...n.position },
+      expanded: n.data?.expanded as boolean | undefined,
+      isExpanded: n.data?.isExpanded as boolean | undefined,
+      onExpandChange: n.data?.onExpandChange as ((e: boolean) => void) | undefined,
+    }])
+  );
 }
-
 
 export const useIliSchema = (
+  nodes: IliNode[],
   setNodes: Dispatch<SetStateAction<IliNode[]>>,
   setEdges: Dispatch<SetStateAction<Edge[]>>,
   useCurvedLines: boolean,
-  setUseCurvedLines: Dispatch<SetStateAction<boolean>>,
-  fitView: (options?: FitViewOptions) => void
+  setUseCurvedLines: Dispatch<SetStateAction<boolean>>
 ): UseIliSchemaReturn => {
   const { colors } = useTheme();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [parseWarnings, setParseWarnings] = useState<IliParseError[]>([]);
-  const dismissParseWarnings = useCallback(() => setParseWarnings([]), []);
-  const [imports, setImports] = useState<IliImportRef[]>([]);
-  const [interlisVersion, setInterlisVersion] = useState<string | undefined>(undefined);
   const [overviewWasShown, setOverviewWasShown] = useState(false);
   const [searchValue, setSearchValue] = useState<SearchOption | null>(null);
-  const [searchOptions, setSearchOptions] = useState<SearchOption[]>([]);
-  const [currentFileName, setCurrentFileName] = useState<string | null>(null);
-  const [nav, setNav] = useState<NavStack>({ entries: [], index: -1 });
+
+  const onNavigateRef = useRef<(entry: NavigationState) => boolean>(() => false);
+  const handleNavigate = useCallback(
+    (entry: NavigationState) => onNavigateRef.current(entry),
+    []
+  );
+  const nav = useNavigationHistory<NavigationState>({ onNavigate: handleNavigate });
   const navigationHistory = nav.entries;
   const historyIndex = nav.index;
+  const pushHistory = nav.push;
+  const resetHistory = nav.reset;
 
-  const pushHistory = useCallback((entry: NavigationState) => {
-    setNav(prev => {
-      const truncated = prev.entries.slice(0, prev.index + 1);
-      const appended = [...truncated, entry];
-      if (appended.length > NAV_HISTORY_LIMIT) {
-        const dropped = appended.slice(appended.length - NAV_HISTORY_LIMIT);
-        return { entries: dropped, index: dropped.length - 1 };
-      }
-      return { entries: appended, index: appended.length - 1 };
-    });
-  }, []);
-
-  const resetHistory = useCallback((seed?: NavigationState) => {
-    setNav(seed ? { entries: [seed], index: 0 } : { entries: [], index: -1 });
-  }, []);
-  const [showFullHierarchy, setShowFullHierarchy] = useState(true);
-  const [allNodes, setAllNodes] = useState<Node[]>([]);
-  const [allEdges, setAllEdges] = useState<Edge[]>([]);
+  const display = useDisplayToggles();
+  const {
+    showFullHierarchy,
+    setShowFullHierarchy,
+    showEnums,
+    setShowEnums,
+    showAssociations,
+    setShowAssociations,
+    maxSubTypesPerRow,
+    setMaxSubTypesPerRow,
+    resetVisibility,
+  } = display;
   const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
-  const [showEnums, setShowEnums] = useState(true);
-  const [showAssociations, setShowAssociations] = useState(true);
-  const [maxSubTypesPerRow, setMaxSubTypesPerRow] = useState<number>(4);
-  const [currentNodes, setCurrentNodes] = useState<Node[]>([]);
-  const [currentEdges, setCurrentEdges] = useState<Edge[]>([]);
-  const [viewportHistory, setViewportHistory] = useState<ViewportState[]>([]);
-  const [enumHistory, setEnumHistory] = useState<Map<string, boolean>>(new Map());
-  const [associationHistory, setAssociationHistory] = useState<Map<string, boolean>>(new Map());
-  const [useMagicLayout, setUseMagicLayout] = useState(false);
-  const [nodeWidths, setNodeWidths] = useState<Map<string, number>>(new Map());
   const [fitViewRequest, setFitViewRequest] = useState(0);
 
   const requestFitView = useCallback(() => {
     setFitViewRequest(c => c + 1);
   }, []);
 
-  const { parserBackend } = useSettings();
-  const schemaServiceRef = useRef<IliSchemaService>(
-    new IliSchemaService(parserBackend === 'ng' ? new NgIliParser() : new LegacyIliParser())
+  const handleLoadedRef = useRef<(result: LoadResult) => void>(() => {});
+  const onLoaded = useCallback(
+    (result: LoadResult) => handleLoadedRef.current(result),
+    []
   );
-  const lastContentRef = useRef<{ content: string; fileName: string } | null>(null);
-  const isResizingRef = useRef(false);
+  const loader = useIliLoader({ colors, useCurvedLines, onLoaded });
+  const {
+    isLoading,
+    error,
+    parseWarnings,
+    dismissParseWarnings,
+    imports,
+    interlisVersion,
+    currentFileName,
+    allNodes,
+    allEdges,
+    relations: parsedRelations,
+    searchOptions,
+    loadFromFile,
+  } = loader;
 
   const computeLayout = useCallback(
     (node: IliNode, override?: Partial<LayoutOptions>) => {
@@ -197,176 +197,109 @@ export const useIliSchema = (
     [computeLayout, setNodes, setEdges]
   );
 
-  const applyLayoutRef = useRef(applyLayout);
-  useEffect(() => {
-    applyLayoutRef.current = applyLayout;
-  });
-
-  const filterNodesAndEdges = useCallback((nodeId: string | null = null) => {
-    const targetNode = nodeId
-      ? (allNodes.find(n => n.id === nodeId) as IliNode | undefined)
-      : ((allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
-          allNodes.find(n => n.type === 'classNode')) as IliNode | undefined);
-
-    if (!targetNode) return;
-
-    applyLayout(targetNode, nodeId ? undefined : { maxSubTypesPerRow: 4 });
-    setActiveNodeId(targetNode.id);
-  }, [allNodes, applyLayout]);
-
-  const loadFromContent = useCallback(async (content: string, fileName: string) => {
-    try {
-      setNodes([]);
-      setEdges([]);
-      setAllNodes([]);
-      setAllEdges([]);
-      setSearchOptions([]);
-      setSearchValue(null);
-      setError(null);
-      resetHistory();
-      setActiveNodeId(null);
-      setMaxSubTypesPerRow(4);
-      setIsLoading(true);
-      setCurrentFileName(fileName);
-
-      lastContentRef.current = { content, fileName };
-      schemaServiceRef.current.parseSchema(content);
-      setParseWarnings(schemaServiceRef.current.getParseErrors());
-      setImports(schemaServiceRef.current.getImports());
-      setInterlisVersion(schemaServiceRef.current.getInterlisVersion());
-
-      const baseNodes = schemaServiceRef.current.getNodes();
-      const relations = schemaServiceRef.current.getRelations();
-
-      const flowNodes = baseNodes.map(flowNodeFromBaseNode);
-      const flowEdges = inheritanceEdgesFromRelations(relations, colors, useCurvedLines);
-
-     
-      setAllNodes(flowNodes);
-      setAllEdges(flowEdges);
-      setSearchOptions(generateSearchOptions(baseNodes));
-
-     
-      const useOverviewLayout = isOverviewCandidate(flowNodes as IliNode[], relations);
-
-      if (useOverviewLayout) {
-        const overview = layoutModelOverview(flowNodes as IliNode[], relations);
-        setNodes(overview.nodes);
-        setEdges(overview.edges);
-        setActiveNodeId(null);
-        resetHistory({
-          nodeId: '__overview__',
-          isOverview: true,
-          showEnums: true,
-          showAssociations: true,
-        });
-        setOverviewWasShown(true);
-      } else {
-        setOverviewWasShown(false);
-        const initialClass = (
-          flowNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
-          flowNodes.find(n => n.type === 'classNode')
-        ) as IliNode | undefined;
-
-        if (initialClass) {
-          const relatedNodes = IliLayoutService.getDirectRelations(
-            initialClass,
-            flowNodes as IliNode[],
-            flowEdges,
-            colors,
-            {
-              showFullHierarchy,
-              useCurvedLines,
-              showEnums,
-              showAssociations,
-              maxSubTypesPerRow: 4,
-              useMagicLayout: false,
-            }
-          );
-
-          setNodes(relatedNodes.nodes);
-          setEdges(relatedNodes.edges);
-          setActiveNodeId(initialClass.id);
-          resetHistory({
-            nodeId: initialClass.id,
-            showEnums: true,
-            showAssociations: showAssociations
-          });
-
-          requestAnimationFrame(() => {
-            setMaxSubTypesPerRow(4);
-          });
-        }
-      }
-
+  const commitDisplay = useCallback(
+    (result: { nodes: IliNode[]; edges: Edge[] }, activeId: string | null) => {
+      setNodes(result.nodes);
+      setEdges(result.edges);
+      setActiveNodeId(activeId);
       requestFitView();
+    },
+    [setNodes, setEdges, requestFitView]
+  );
 
-    } catch (error) {
-      setError(error instanceof Error ? error.message : 'Fehler beim Laden des Schemas');
-      setCurrentFileName(null);
-    } finally {
-      setIsLoading(false);
+  const displayNode = useCallback((target: DisplayTarget): boolean => {
+    if (target.kind === 'overview') {
+      if (allNodes.length === 0) return false;
+      const overview = layoutModelOverview(allNodes as IliNode[], parsedRelations);
+      commitDisplay({ nodes: overview.nodes as IliNode[], edges: overview.edges }, null);
+    } else {
+      commitDisplay(computeLayout(target.node, target.override), target.node.id);
     }
+    return true;
+  }, [allNodes, parsedRelations, computeLayout, commitDisplay]);
+
+  const handleLoaded = useCallback((result: LoadResult) => {
+    setSearchValue(null);
+    setMaxSubTypesPerRow(4);
+    resetHistory();
+
+    if (isOverviewCandidate(result.flowNodes as IliNode[], result.relations)) {
+      const overview = layoutModelOverview(result.flowNodes as IliNode[], result.relations);
+      commitDisplay({ nodes: overview.nodes as IliNode[], edges: overview.edges }, null);
+      resetHistory({
+        nodeId: '__overview__',
+        isOverview: true,
+        showEnums: true,
+        showAssociations: true,
+      });
+      setOverviewWasShown(true);
+      return;
+    }
+
+    setOverviewWasShown(false);
+    const initialClass = (
+      result.flowNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
+      result.flowNodes.find(n => n.type === 'classNode')
+    ) as IliNode | undefined;
+    if (!initialClass) return;
+
+    const layoutResult = IliLayoutService.getDirectRelations(
+      initialClass,
+      result.flowNodes as IliNode[],
+      result.flowEdges,
+      colors,
+      {
+        showFullHierarchy,
+        useCurvedLines,
+        showEnums,
+        showAssociations,
+        maxSubTypesPerRow: 4,
+        useMagicLayout: false,
+      }
+    );
+    commitDisplay(layoutResult, initialClass.id);
+    resetHistory({
+      nodeId: initialClass.id,
+      showEnums: true,
+      showAssociations,
+    });
+    requestAnimationFrame(() => setMaxSubTypesPerRow(4));
   }, [
     colors,
     showFullHierarchy,
     useCurvedLines,
     showEnums,
     showAssociations,
-    setNodes,
-    setEdges,
-    requestFitView,
+    setMaxSubTypesPerRow,
+    resetHistory,
+    commitDisplay,
   ]);
 
-  const handleFileUpload = useCallback(async (file: File) => {
-    const content = await readFileAsText(file);
-    await loadFromContent(content, file.name);
-  }, [loadFromContent]);
-
-  const loadFromContentRef = useRef(loadFromContent);
   useEffect(() => {
-    loadFromContentRef.current = loadFromContent;
+    handleLoadedRef.current = handleLoaded;
   });
 
-  useEffect(() => {
-    schemaServiceRef.current = new IliSchemaService(
-      parserBackend === 'ng' ? new NgIliParser() : new LegacyIliParser()
-    );
-    const cached = lastContentRef.current;
-    if (cached) {
-      void loadFromContentRef.current(cached.content, cached.fileName);
-    }
-  }, [parserBackend]);
+  const handleFileUpload = loadFromFile;
 
   const handleSearchChange = useCallback((option: SearchOption | null) => {
     setSearchValue(option);
-    if (option) {
-     
-      const nodeId = option.type === 'ATTRIBUTE' 
-        ? option.id.split('.')[0] 
-        : option.id;
-
-      const processedNode = {
-        ...option,
-        id: nodeId, 
-        type: option.type === 'ENUMERATION' ? 'enumNode' : 'CLASS', 
-        position: { x: 0, y: 0 },
-        data: {
-          ...option,
-          isHighlighted: false,
-          isActive: false
-        }
-      };
-
-      applyLayout(processedNode as IliNode);
-      setActiveNodeId(nodeId);
-      requestFitView();
-      setSearchValue(null);
-    } else {
-     
-      filterNodesAndEdges(null);
+    if (!option) {
+      const fallback = (allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
+        allNodes.find(n => n.type === 'classNode')) as IliNode | undefined;
+      if (fallback) displayNode({ kind: 'node', node: fallback, override: { maxSubTypesPerRow: 4 } });
+      return;
     }
-  }, [filterNodesAndEdges, showAssociations, allNodes, allEdges, colors, showFullHierarchy, useCurvedLines, showEnums, maxSubTypesPerRow, fitView]);
+    const nodeId = option.type === 'ATTRIBUTE' ? option.id.split('.')[0] : option.id;
+    const processedNode = {
+      ...option,
+      id: nodeId,
+      type: option.type === 'ENUMERATION' ? 'enumNode' : 'CLASS',
+      position: { x: 0, y: 0 },
+      data: { ...option, isHighlighted: false, isActive: false },
+    } as unknown as IliNode;
+    displayNode({ kind: 'node', node: processedNode });
+    setSearchValue(null);
+  }, [allNodes, displayNode]);
 
   const handleConnect = useCallback((params: Connection) => {
     if (params.source && params.target) {
@@ -385,105 +318,40 @@ export const useIliSchema = (
     }
   }, [setEdges, useCurvedLines]);
 
-  const handleNodeClick = useCallback((event: React.MouseEvent, node: Node, viewport: ViewportState) => {
+  const handleNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     if (node.id === activeNodeId) return;
 
-    setNodeWidths(new Map());
+    const iliNode = normalizeIliNode(node, { width: 400 });
+    const result = computeLayout(iliNode);
+    const widened = result.nodes.map(n => ({ ...n, data: { ...n.data, width: 400 } }));
 
-    const iliNode: IliNode = {
-      ...node,
-      type: node.type || 'classNode',
-      position: node.position,
-      data: {
-        ...node.data,
-        isHighlighted: false,
-        isActive: false,
-        expanded: node.data?.expanded ?? false,
-        width: 400
-      }
-    };
-
-    const relatedNodes = computeLayout(iliNode);
-
-    const nodesWithDefaultWidth = relatedNodes.nodes.map(n => ({
-      ...n,
-      data: {
-        ...n.data,
-        width: 400
-      }
-    }));
-
-    setNodes(nodesWithDefaultWidth);
-    setEdges(relatedNodes.edges);
+    setNodes(widened);
+    setEdges(result.edges);
     setActiveNodeId(node.id);
-
-    pushHistory({
-      nodeId: node.id,
-      node: iliNode,
-      showEnums,
-      showAssociations,
-    });
-
-    setViewportHistory(prev => [...prev, viewport]);
-
-    if (!isResizingRef.current) {
-      requestFitView();
-    }
-  }, [
-    activeNodeId,
-    computeLayout,
-    showEnums,
-    showAssociations,
-    setNodes,
-    setEdges,
-    requestFitView,
-    pushHistory,
-  ]);
-
-  const renderOverviewLayout = useCallback(() => {
-    if (allNodes.length === 0) return false;
-    const relations = schemaServiceRef.current.getRelations();
-    const overview = layoutModelOverview(allNodes as IliNode[], relations);
-    setNodes(overview.nodes as IliNode[]);
-    setEdges(overview.edges);
-    setActiveNodeId(null);
-    return true;
-  }, [allNodes, setNodes, setEdges]);
+    pushHistory({ nodeId: node.id, node: iliNode, showEnums, showAssociations });
+    requestFitView();
+  }, [activeNodeId, computeLayout, showEnums, showAssociations, setNodes, setEdges, requestFitView, pushHistory]);
 
   const navigateToEntry = useCallback((entry: NavigationState) => {
     if (entry.isOverview) {
-      if (!renderOverviewLayout()) return false;
-      requestFitView();
-      return true;
+      return displayNode({ kind: 'overview' });
     }
-
     const target = entry.node
       ?? (allNodes.find(node => node.id === entry.nodeId) as IliNode | undefined);
     if (!target) return false;
 
     setShowAssociations(entry.showAssociations);
     setShowEnums(entry.showEnums);
-
-    const iliNode: IliNode = {
-      ...target,
-      type: target.type || 'classNode',
-      position: target.position,
-      data: {
-        ...target.data,
-        isHighlighted: false,
-        isActive: false,
-        expanded: target.data?.expanded ?? false,
-      },
-    };
-
-    applyLayoutRef.current(iliNode, {
-      showEnums: entry.showEnums,
-      showAssociations: entry.showAssociations,
+    return displayNode({
+      kind: 'node',
+      node: normalizeIliNode(target),
+      override: { showEnums: entry.showEnums, showAssociations: entry.showAssociations },
     });
-    setActiveNodeId(entry.nodeId);
-    requestFitView();
-    return true;
-  }, [allNodes, requestFitView, renderOverviewLayout]);
+  }, [allNodes, displayNode, setShowEnums, setShowAssociations]);
+
+  useEffect(() => {
+    onNavigateRef.current = navigateToEntry;
+  });
 
   const navigateToNode = useCallback((nodeId: string): boolean => {
     const target = allNodes.find(node => node.id === nodeId) as IliNode | undefined;
@@ -501,30 +369,18 @@ export const useIliSchema = (
     return true;
   }, [allNodes, activeNodeId, showEnums, showAssociations, navigateToEntry, pushHistory]);
 
-  const canGoBack = useMemo(() => historyIndex > 0, [historyIndex]);
+  const canGoBack = nav.canGoBack;
+  const canGoForward = nav.canGoForward;
 
-  const canGoForward = useMemo(() => {
-    return navigationHistory.length > 0 && historyIndex < navigationHistory.length - 1;
-  }, [historyIndex, navigationHistory.length]);
-
-  // Single entry point that returns the user to the initial state for the
-  // current model: renders the topic-grouped overview and resets all
-  // session-only toggles (enum/association history, visibility flags, max
-  // sub-types per row). Replaces the previous Reset action.
   const showOverview = useCallback(() => {
     if (allNodes.length === 0) return;
     const currentEntry = nav.entries[nav.index];
     if (currentEntry?.isOverview) {
-      renderOverviewLayout();
-      requestFitView();
+      displayNode({ kind: 'overview' });
       return;
     }
-    setEnumHistory(new Map());
-    setAssociationHistory(new Map());
-    setShowEnums(true);
-    setShowAssociations(true);
-    setMaxSubTypesPerRow(4);
-    if (!renderOverviewLayout()) return;
+    resetVisibility();
+    if (!displayNode({ kind: 'overview' })) return;
     pushHistory({
       nodeId: '__overview__',
       isOverview: true,
@@ -532,73 +388,30 @@ export const useIliSchema = (
       showAssociations: true,
     });
     setOverviewWasShown(true);
-    requestFitView();
-  }, [allNodes, nav, renderOverviewLayout, pushHistory, requestFitView]);
+  }, [allNodes, nav, displayNode, pushHistory, resetVisibility]);
 
-  const handleBack = useCallback((): boolean => {
-    if (historyIndex <= 0) return false;
-    const targetEntry = navigationHistory[historyIndex - 1];
-    if (!navigateToEntry(targetEntry)) return false;
-    setNav(prev => ({ ...prev, index: prev.index - 1 }));
-    return true;
-  }, [historyIndex, navigationHistory, navigateToEntry]);
-
-  const handleForward = useCallback((): boolean => {
-    if (!canGoForward) return false;
-    const targetEntry = navigationHistory[historyIndex + 1];
-    if (!navigateToEntry(targetEntry)) return false;
-    setNav(prev => ({ ...prev, index: prev.index + 1 }));
-    return true;
-  }, [canGoForward, historyIndex, navigationHistory, navigateToEntry]);
-
-  const jumpToHistoryIndex = useCallback((targetIndex: number): boolean => {
-    if (targetIndex < 0 || targetIndex >= navigationHistory.length) return false;
-    if (targetIndex === historyIndex) return false;
-    const targetEntry = navigationHistory[targetIndex];
-    if (!navigateToEntry(targetEntry)) return false;
-    setNav(prev => ({ ...prev, index: targetIndex }));
-    return true;
-  }, [navigationHistory, historyIndex, navigateToEntry]);
+  const handleBack = nav.back;
+  const handleForward = nav.forward;
+  const jumpToHistoryIndex = nav.jumpTo;
 
   const handleClearFile = useCallback(() => {
+    loader.clear();
     setNodes([]);
     setEdges([]);
-    setAllNodes([]);
-    setAllEdges([]);
-    setSearchOptions([]);
     setSearchValue(null);
-    setCurrentFileName(null);
-    setError(null);
-    setParseWarnings([]);
-    setImports([]);
-    setInterlisVersion(undefined);
     setOverviewWasShown(false);
     resetHistory();
     setActiveNodeId(null);
-    setMaxSubTypesPerRow(4);
-    setShowEnums(true);
-    setShowAssociations(true);
-    setEnumHistory(new Map());
-    setAssociationHistory(new Map());
-  }, [setNodes, setEdges, resetHistory]);
+    resetVisibility();
+  }, [loader, setNodes, setEdges, resetHistory, resetVisibility]);
 
-  // Setting full-hierarchy from the layout-settings panel: flip the flag and
-  // bring the user back to the initial view (overview if multi-root, else the
-  // abstract base class) using the new value as override so the closure
-  // staleness from setShowFullHierarchy doesn't matter.
   const setFullHierarchyAndReset = useCallback((value: boolean) => {
     setShowFullHierarchy(value);
-    setEnumHistory(new Map());
-    setAssociationHistory(new Map());
     setShowEnums(true);
     setShowAssociations(true);
 
-    const relations = schemaServiceRef.current.getRelations();
-    if (isOverviewCandidate(allNodes as IliNode[], relations)) {
-      const overview = layoutModelOverview(allNodes as IliNode[], relations);
-      setNodes(overview.nodes as IliNode[]);
-      setEdges(overview.edges);
-      setActiveNodeId(null);
+    if (isOverviewCandidate(allNodes as IliNode[], parsedRelations)) {
+      displayNode({ kind: 'overview' });
       resetHistory({
         nodeId: '__overview__',
         isOverview: true,
@@ -606,7 +419,6 @@ export const useIliSchema = (
         showAssociations: true,
       });
       setOverviewWasShown(true);
-      requestFitView();
       return;
     }
 
@@ -614,76 +426,66 @@ export const useIliSchema = (
     const initialClass =
       allNodes.find(n => n.type === 'classNode' && n.data.isAbstract) ??
       allNodes.find(n => n.type === 'classNode');
-    if (initialClass) {
-      const result = computeLayout(initialClass as IliNode, {
+    if (!initialClass) return;
+
+    displayNode({
+      kind: 'node',
+      node: initialClass as IliNode,
+      override: {
         showFullHierarchy: value,
         showEnums: true,
         showAssociations: true,
         maxSubTypesPerRow: 4,
-      });
-      setNodes(result.nodes);
-      setEdges(result.edges);
-      setActiveNodeId(initialClass.id);
-      resetHistory({
-        nodeId: initialClass.id,
-        showEnums: true,
-        showAssociations: true,
-      });
-      requestFitView();
-    }
-  }, [allNodes, computeLayout, setNodes, setEdges, requestFitView, resetHistory]);
+      },
+    });
+    resetHistory({
+      nodeId: initialClass.id,
+      showEnums: true,
+      showAssociations: true,
+    });
+  }, [allNodes, parsedRelations, displayNode, setShowFullHierarchy, setShowEnums, setShowAssociations, resetHistory]);
 
   const handleToggleEnums = useCallback((visible: boolean) => {
     setShowEnums(visible);
-    
-    if (activeNodeId) {
-      const currentNode = allNodes.find(node => node.id === activeNodeId);
-      if (currentNode) {
-       
-        const nodeStates = new Map(
-          currentNodes.map(node => [
-            node.id,
-            {
-              position: { ...node.position },
-              expanded: node.data?.expanded,
-              isExpanded: node.data?.isExpanded,
-              onExpandChange: node.data?.onExpandChange
-            }
-          ])
-        );
 
-        const relatedNodes = computeLayout(currentNode as IliNode, { showEnums: visible });
+    if (!activeNodeId) return;
+    const currentNode = allNodes.find(node => node.id === activeNodeId);
+    if (!currentNode) return;
 
-        const updatedNodes = relatedNodes.nodes.map(node => {
-          const savedState = nodeStates.get(node.id);
-          if (savedState) {
-            return {
-              ...node,
-              position: savedState.position,
-              data: {
-                ...node.data,
-                expanded: savedState.expanded,
-                isExpanded: savedState.isExpanded,
-                onExpandChange: savedState.onExpandChange
-              }
-            };
-          }
-          return node;
-        });
+    const captured = captureNodeStates(nodes);
+    const relatedNodes = computeLayout(currentNode as IliNode, { showEnums: visible });
 
-        setNodes(updatedNodes);
-        setEdges(relatedNodes.edges);
-      }
-    }
-  }, [activeNodeId, allNodes, computeLayout, currentNodes, setNodes, setEdges]);
+    const updatedNodes = relatedNodes.nodes.map(node => {
+      const saved = captured.get(node.id);
+      if (!saved) return node;
+      return {
+        ...node,
+        position: saved.position,
+        data: {
+          ...node.data,
+          expanded: saved.expanded,
+          isExpanded: saved.isExpanded,
+          onExpandChange: saved.onExpandChange,
+        },
+      };
+    });
 
- 
+    setNodes(updatedNodes);
+    setEdges(relatedNodes.edges);
+  }, [activeNodeId, allNodes, computeLayout, nodes, setNodes, setEdges, setShowEnums]);
+
+  const handleMaxSubTypesChange = useCallback((value: number) => {
+    setMaxSubTypesPerRow(value);
+    if (!activeNodeId) return;
+    const currentNode = allNodes.find(n => n.id === activeNodeId);
+    if (!currentNode) return;
+    applyLayout(currentNode as IliNode, { maxSubTypesPerRow: value });
+  }, [activeNodeId, allNodes, applyLayout, setMaxSubTypesPerRow]);
+
   useEffect(() => {
     return () => {
-     
       setNodes([]);
       setEdges([]);
-      setSearchOptions([]);
     };
   }, []);
 
@@ -695,7 +497,7 @@ export const useIliSchema = (
         n.type === 'classNode' && n.data.isAbstract
       );
       if (firstAbstractClass) {
-        applyLayoutRef.current(firstAbstractClass as IliNode, { maxSubTypesPerRow: 4 });
+        applyLayout(firstAbstractClass as IliNode, { maxSubTypesPerRow: 4 });
         setActiveNodeId(firstAbstractClass.id);
         resetHistory({
           nodeId: firstAbstractClass.id,
@@ -704,52 +506,31 @@ export const useIliSchema = (
         });
       }
     }
-  }, [activeNodeId, allNodes, overviewWasShown, resetHistory]);
-
-
-  useEffect(() => {
-    if (activeNodeId && allNodes.length > 0) {
-      const currentNode = allNodes.find(node => node.id === activeNodeId);
-      if (currentNode) {
-        const relatedNodes = applyLayoutRef.current(currentNode as IliNode);
-        setCurrentNodes(relatedNodes.nodes);
-        setCurrentEdges(relatedNodes.edges);
-      }
-    }
-  }, [activeNodeId, allNodes]);
+  }, [activeNodeId, allNodes, overviewWasShown, applyLayout, resetHistory]);
 
   const handleLineTypeToggle = useCallback(() => {
     setUseCurvedLines(prev => {
       const newValue = !prev;
-      
-      const expandedStates = new Map<string, boolean>(
-        currentNodes.map(node => [node.id, Boolean(node.data?.expanded)] as const)
-      );
-      
-      const nodePositions = new Map<string, { x: number; y: number }>(
-        currentNodes.map(node => [node.id, { ...node.position }])
-      );
+      const captured = captureNodeStates(nodes);
 
-      setEdges(edges => edges.map(edge => ({
+      setEdges(prevEdges => prevEdges.map(edge => ({
         ...edge,
-        type: newValue ? 'default' : 'step'
+        type: newValue ? 'default' : 'step',
       })));
 
-      const updatedNodes = currentNodes.map(node => ({
-        ...node,
-        position: nodePositions.get(node.id) || node.position,
-        data: {
-          ...node.data,
-          expanded: expandedStates.get(node.id) ?? node.data?.expanded
-        }
-      }));
+      const updatedNodes = nodes.map(node => {
+        const saved = captured.get(node.id);
+        return {
+          ...node,
+          position: saved?.position ?? node.position,
+          data: { ...node.data, expanded: saved?.expanded ?? node.data?.expanded },
+        };
+      });
 
       setNodes(updatedNodes);
-      setCurrentNodes(updatedNodes);
-
       return newValue;
     });
-  }, [currentNodes, setNodes, setEdges]);
+  }, [nodes, setNodes, setEdges, setUseCurvedLines]);
 
   const handleToggleAssociations = useCallback((visible: boolean) => {
     setShowAssociations(visible);
@@ -758,17 +539,10 @@ export const useIliSchema = (
       const currentNode = allNodes.find(node => node.id === activeNodeId);
       if (currentNode) {
         applyLayout(currentNode as IliNode, { showAssociations: visible });
-
-        setNav(prev => {
-          if (prev.index < 0) return prev;
-          const updated = prev.entries.map((entry, idx) =>
-            idx === prev.index ? { ...entry, showAssociations: visible } : entry
-          );
-          return { entries: updated, index: prev.index };
-        });
+        nav.patchCurrent({ showAssociations: visible });
       }
     }
-  }, [activeNodeId, allNodes, applyLayout, navigationHistory, historyIndex]);
+  }, [activeNodeId, allNodes, applyLayout, nav]);
 
   const resetCurrentLayout = useCallback(() => {
     if (!activeNodeId) return;
@@ -779,65 +553,27 @@ export const useIliSchema = (
   }, [activeNodeId, allNodes, applyLayout, requestFitView]);
 
   const handleMagicLayout = useCallback(() => {
-    if (activeNodeId) {
-      const currentNode = allNodes.find(node => node.id === activeNodeId);
-      if (currentNode) {
-        const expandedHandlers = new Map(
-          currentNodes.map(node => [node.id, node.data?.onExpandChange])
-        );
+    if (!activeNodeId) return;
+    const currentNode = allNodes.find(node => node.id === activeNodeId);
+    if (!currentNode) return;
 
-        const relatedNodes = computeLayout(currentNode as IliNode, { useMagicLayout: true });
+    const captured = captureNodeStates(nodes);
+    const relatedNodes = computeLayout(currentNode as IliNode, { useMagicLayout: true });
 
-        const nodesWithExpandedStates = relatedNodes.nodes.map(node => ({
-          ...node,
-          data: {
-            ...node.data,
-            expanded: true,
-            isExpanded: true,
-            onExpandChange: expandedHandlers.get(node.id) || node.data?.onExpandChange
-          }
-        }));
+    const nodesWithExpandedStates = relatedNodes.nodes.map(node => ({
+      ...node,
+      data: {
+        ...node.data,
+        expanded: true,
+        isExpanded: true,
+        onExpandChange: captured.get(node.id)?.onExpandChange ?? node.data?.onExpandChange,
+      },
+    }));
 
-        setNodes(nodesWithExpandedStates);
-        setCurrentNodes(nodesWithExpandedStates);
-        setEdges(relatedNodes.edges);
-        setCurrentEdges(relatedNodes.edges);
-      }
-    }
-  }, [activeNodeId, allNodes, computeLayout, currentNodes, setNodes, setEdges]);
+    setNodes(nodesWithExpandedStates);
+    setEdges(relatedNodes.edges);
+  }, [activeNodeId, allNodes, computeLayout, nodes, setNodes, setEdges]);
 
-  const handleNodeResize = useCallback((nodeId: string, width: number) => {
-   
-    isResizingRef.current = true;
-    
-    setNodeWidths(prev => {
-      const newWidths = new Map(prev);
-      newWidths.set(nodeId, width);
-      return newWidths;
-    });
-
-    setNodes(currentNodes => 
-      currentNodes.map(node => 
-        node.id === nodeId 
-          ? {
-              ...node,
-              data: {
-                ...node.data,
-                width
-              },
-              position: node.position
-            }
-          : node
-      )
-    );
-
-   
-    setTimeout(() => {
-      isResizingRef.current = false;
-    }, 100);
-  }, []);
-
- 
   return {
     isLoading,
     error,
@@ -874,14 +610,11 @@ export const useIliSchema = (
     maxSubTypesPerRow,
     setMaxSubTypesPerRow,
     handleLineTypeToggle,
-    currentNodes,
-    currentEdges,
     showAssociations,
     handleToggleAssociations,
     handleMagicLayout,
     resetCurrentLayout,
-    applyLayout,
-    computeLayout,
+    handleMaxSubTypesChange,
     fitViewRequest,
     requestFitView,
   };

--- a/src/features/ili-explorer/hooks/useNavigationHistory.ts
+++ b/src/features/ili-explorer/hooks/useNavigationHistory.ts
@@ -1,0 +1,103 @@
+import { useState, useCallback, useMemo } from 'react';
+
+interface NavStack<T> {
+  entries: T[];
+  index: number;
+}
+
+interface UseNavigationHistoryOptions<T> {
+  limit?: number;
+  onNavigate: (entry: T) => boolean;
+}
+
+export interface UseNavigationHistoryReturn<T> {
+  entries: T[];
+  index: number;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  push: (entry: T) => void;
+  reset: (seed?: T) => void;
+  back: () => boolean;
+  forward: () => boolean;
+  jumpTo: (targetIndex: number) => boolean;
+  patchCurrent: (patch: Partial<T>) => void;
+}
+
+const DEFAULT_LIMIT = 50;
+
+export function useNavigationHistory<T>(
+  options: UseNavigationHistoryOptions<T>
+): UseNavigationHistoryReturn<T> {
+  const { limit = DEFAULT_LIMIT, onNavigate } = options;
+  const [nav, setNav] = useState<NavStack<T>>({ entries: [], index: -1 });
+
+  const push = useCallback((entry: T) => {
+    setNav(prev => {
+      const truncated = prev.entries.slice(0, prev.index + 1);
+      const appended = [...truncated, entry];
+      if (appended.length > limit) {
+        const dropped = appended.slice(appended.length - limit);
+        return { entries: dropped, index: dropped.length - 1 };
+      }
+      return { entries: appended, index: appended.length - 1 };
+    });
+  }, [limit]);
+
+  const reset = useCallback((seed?: T) => {
+    setNav(seed ? { entries: [seed], index: 0 } : { entries: [], index: -1 });
+  }, []);
+
+  const canGoBack = useMemo(() => nav.index > 0, [nav.index]);
+  const canGoForward = useMemo(
+    () => nav.entries.length > 0 && nav.index < nav.entries.length - 1,
+    [nav.index, nav.entries.length]
+  );
+
+  const back = useCallback((): boolean => {
+    if (nav.index <= 0) return false;
+    const target = nav.entries[nav.index - 1];
+    if (!onNavigate(target)) return false;
+    setNav(prev => ({ ...prev, index: prev.index - 1 }));
+    return true;
+  }, [nav, onNavigate]);
+
+  const forward = useCallback((): boolean => {
+    if (!(nav.entries.length > 0 && nav.index < nav.entries.length - 1)) return false;
+    const target = nav.entries[nav.index + 1];
+    if (!onNavigate(target)) return false;
+    setNav(prev => ({ ...prev, index: prev.index + 1 }));
+    return true;
+  }, [nav, onNavigate]);
+
+  const jumpTo = useCallback((targetIndex: number): boolean => {
+    if (targetIndex < 0 || targetIndex >= nav.entries.length) return false;
+    if (targetIndex === nav.index) return false;
+    const target = nav.entries[targetIndex];
+    if (!onNavigate(target)) return false;
+    setNav(prev => ({ ...prev, index: targetIndex }));
+    return true;
+  }, [nav, onNavigate]);
+
+  const patchCurrent = useCallback((patch: Partial<T>) => {
+    setNav(prev => {
+      if (prev.index < 0) return prev;
+      const updated = prev.entries.map((entry, idx) =>
+        idx === prev.index ? { ...entry, ...patch } : entry
+      );
+      return { entries: updated, index: prev.index };
+    });
+  }, []);
+
+  return {
+    entries: nav.entries,
+    index: nav.index,
+    canGoBack,
+    canGoForward,
+    push,
+    reset,
+    back,
+    forward,
+    jumpTo,
+    patchCurrent,
+  };
+}

--- a/src/features/ili-explorer/services/iliSchemaService.ts
+++ b/src/features/ili-explorer/services/iliSchemaService.ts
@@ -9,7 +9,7 @@ import {
   IliClassNode
 } from './types/IliModelTypes';
 import type { IliParser, IliParseError, IliImportRef } from './parsers/IliParser';
-import { LegacyIliParser } from './parsers/LegacyIliParser';
+import { NgIliParser } from './parsers/ng/NgIliParser';
 import { v4 as uuid } from 'uuid';
 
 export class IliSchemaService {
@@ -20,7 +20,7 @@ export class IliSchemaService {
   private lastImports: IliImportRef[] = [];
   private lastInterlisVersion: string | undefined;
 
-  constructor(parser: IliParser = new LegacyIliParser()) {
+  constructor(parser: IliParser = new NgIliParser()) {
     this.nodes = new Map();
     this.relations = new Map();
     this.parser = parser;

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -126,7 +126,9 @@ export function attachClassAssociations(
   });
 
   const baseX = LAYOUT_CONFIG.ASSOCIATION.OFFSET_X;
-  const activeNodeY = entity.position.y;
+  // Active node is positioned at the origin by getDirectRelations; center
+  // associations around y=0 instead of the incoming click position.
+  const activeNodeY = 0;
   const totalAssociations = sortedAssociations.length;
   const spacingY = useMagicLayout
     ? LAYOUT_CONFIG.ASSOCIATION.SPACING_Y * LAYOUT_CONFIG.MAGIC.ASSOCIATION

--- a/src/features/ili-explorer/services/parsers/LegacyIliParser.ts
+++ b/src/features/ili-explorer/services/parsers/LegacyIliParser.ts
@@ -1,8 +1,0 @@
-import { IliParserService } from '../IliParserService';
-import type { IliParser, IliParseResult } from './IliParser';
-
-export class LegacyIliParser implements IliParser {
-  parseContent(content: string): IliParseResult {
-    return new IliParserService().parseContent(content);
-  }
-}

--- a/src/features/ili-explorer/services/parsers/ng/__tests__/conformance.test.ts
+++ b/src/features/ili-explorer/services/parsers/ng/__tests__/conformance.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { NgIliParser } from '../NgIliParser';
-import { LegacyIliParser } from '../../LegacyIliParser';
 import { IliLexer } from '../tokens';
 import { cstParserInstance } from '../parser';
 
@@ -57,17 +56,6 @@ describe('NgIliParser conformance — real INTERLIS schemas', () => {
         expect(cls.name).toBeTruthy();
         expect(cls.data.label).toBe(cls.name);
       }
-    });
-
-    itOrSkip(`${fixture.name}: NG covers at least as many classes as Legacy`, () => {
-      const content = readFileSync(fixture.path, 'utf8');
-      const ng = new NgIliParser().parseContent(content);
-      const legacy = new LegacyIliParser().parseContent(content);
-
-      const ngClassCount = ng.nodes.filter(n => n.type === 'CLASS').length;
-      const legacyClassCount = legacy.nodes.filter(n => n.type === 'CLASS').length;
-
-      expect(ngClassCount).toBeGreaterThanOrEqual(legacyClassCount);
     });
 
     itOrSkip(`${fixture.name}: NG attributes are well-formed`, () => {


### PR DESCRIPTION
…ssociation centering

- Extract useNavigationHistory, useIliLoader, useDisplayToggles from useIliSchema
- Add coordinator helpers: displayNode, commitDisplay, normalizeIliNode, captureNodeStates
- Drop LegacyIliParser, parserBackend setting, Settings UI switcher
- Eliminate concern-bleed: applyLayout/computeLayout no longer exposed; handleMaxSubTypesChange moves into coordinator
- Remove caller-side applyLayoutRef workaround
- Use parent React Flow state as single source of truth (drop currentNodes/currentEdges cache + sync effect)
- Fix association vertical centering: anchor on origin instead of click position (previously masked by removed sync effect)