### PR TITLE
feat(parser): qualified node IDs + parser/UI release-blocker items

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,5 @@
 /*
   X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer-when-downgrade
-  Content-Security-Policy: default-src 'self' http: https: data: blob: 'unsafe-inline'
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' data:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,9 +191,9 @@ function App() {
                 alignItems: 'center', 
                 gap: 2
               }}>
-                <Typography 
-                  variant="caption" 
-                  sx={{ 
+                <Typography
+                  variant="caption"
+                  sx={{
                     color: '#ffffff',
                     fontSize: '0.7rem',
                     userSelect: 'none',

--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -11,7 +11,8 @@ import {
   Radio,
   RadioGroup
 } from '@mui/material';
-import { Settings as SettingsIcon } from '@mui/icons-material';
+import { Settings as SettingsIcon, GitHub } from '@mui/icons-material';
+import { Link as MuiLink } from '@mui/material';
 import { useTheme } from '../theme/ThemeContext';
 import { useSettings } from '../settings/SettingsContext';
 
@@ -172,6 +173,26 @@ const Settings: React.FC = () => {
             }
             label="Experimentelle Features"
           />
+        </MenuItem>
+        <Divider />
+        <MenuItem sx={{ flexDirection: 'column', alignItems: 'flex-start', gap: 0.5 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            modvis V{__APP_VERSION__} · AGPL-3.0
+          </Typography>
+          <MuiLink
+            href={`${__SOURCE_REPO__}/tree/main`}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+              fontSize: '0.8rem',
+            }}
+          >
+            <GitHub fontSize="inherit" />
+            Source-Code auf GitHub
+          </MuiLink>
         </MenuItem>
       </Menu>
     </>

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -37,7 +37,8 @@ import {
   IliDomainEnumNode,
   IliTopicLabelNode,
   IliTopicFrameNode,
-  IliPreviewNode
+  IliPreviewNode,
+  IliUnsupportedNode,
 } from './nodes';
 import { useIliSchema } from '../hooks/useIliSchema';
 import { useDiagramExport } from '../hooks/useDiagramExport';
@@ -51,7 +52,7 @@ import { debounce } from 'lodash';
 
 interface CustomNode extends ReactFlowNode {
   id: string;
-  type: 'modelNode' | 'topicNode' | 'classNode' | 'structureNode' | 'enumNode' | 'associationNode' | 'unloadedClassNode' | 'domainEnumNode';
+  type: 'modelNode' | 'topicNode' | 'classNode' | 'structureNode' | 'enumNode' | 'associationNode' | 'unloadedClassNode' | 'domainEnumNode' | 'unsupportedNode';
   data: {
     label: string;
     isHighlighted?: boolean;
@@ -72,6 +73,7 @@ const nodeTypes: NodeTypes = {
   topicLabelNode: IliTopicLabelNode,
   topicFrameNode: IliTopicFrameNode,
   previewNode: IliPreviewNode,
+  unsupportedNode: IliUnsupportedNode,
 };
 
 
@@ -170,8 +172,6 @@ const Flow: React.FC = () => {
   }, [handleFileUploadBase]);
 
   const [lastFitDone, setLastFitDone] = useState(0);
-  // Fade-in only on initial fit per file; navigations within the file keep
-  // the canvas visible to avoid the brief blank between layout swaps.
   const canvasReady = fitViewRequest === 0 || lastFitDone > 0;
 
   useEffect(() => {

--- a/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
@@ -141,19 +141,27 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
         style={{ opacity: 0 }}
       />
       
-      <Tooltip 
+      <Tooltip
         title={
-          data.comment && (
-            <Box sx={{ p: 1, maxWidth: 400 }}>
-              <Typography variant="caption" sx={{ 
+          <Box sx={{ p: 1, maxWidth: 400 }}>
+            {data.comment && (
+              <Typography variant="caption" sx={{
                 display: 'block',
                 whiteSpace: 'pre-wrap',
-                color: 'text.secondary'
+                color: 'text.secondary',
+                mb: 0.5,
               }}>
                 {data.comment}
               </Typography>
-            </Box>
-          )
+            )}
+            <Typography variant="caption" sx={{ display: 'block', fontFamily: 'monospace', color: 'text.secondary' }}>
+              {getShortClassName(data.association.sourceClass)}
+              {data.association.sourceCardinality && ` [${data.association.sourceCardinality}]`}
+              {' — '}
+              {getShortClassName(data.association.targetClass)}
+              {data.association.targetCardinality && ` [${data.association.targetCardinality}]`}
+            </Typography>
+          </Box>
         }
         placement="top"
         componentsProps={{

--- a/src/features/ili-explorer/components/nodes/IliUnsupportedNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliUnsupportedNode.tsx
@@ -1,0 +1,59 @@
+import React, { memo } from 'react';
+import { Handle, Position } from '@xyflow/react';
+import { Paper, Typography, Box, Tooltip } from '@mui/material';
+import { useTheme } from '../../../../common/theme/ThemeContext';
+import { alpha } from '@mui/material/styles';
+
+interface IliUnsupportedNodeProps {
+  data: {
+    label: string;
+    type?: string;
+    isHighlighted?: boolean;
+    isActive?: boolean;
+    comment?: string;
+  };
+}
+
+export const IliUnsupportedNode: React.FC<IliUnsupportedNodeProps> = memo(({ data }) => {
+  const { colors } = useTheme();
+  const kind = data.type ?? 'UNKNOWN';
+
+  return (
+    <Paper
+      elevation={1}
+      sx={{
+        minWidth: 240,
+        maxWidth: 320,
+        border: `2px dashed ${alpha(colors.text, 0.4)}`,
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: alpha(colors.nodeContent, 0.5),
+        color: colors.text,
+        opacity: data.isActive ? 1 : 0.8,
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+
+      <Tooltip
+        title={data.comment ?? `INTERLIS-${kind} — Visualisierung folgt`}
+        placement="top"
+      >
+        <Box sx={{ p: 1.5, textAlign: 'center' }}>
+          <Typography variant="caption" sx={{ opacity: 0.6, letterSpacing: 1 }}>
+            «{kind}»
+          </Typography>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ wordBreak: 'break-word' }}>
+            {data.label}
+          </Typography>
+          <Typography variant="caption" sx={{ opacity: 0.5, fontStyle: 'italic' }}>
+            Visualisierung folgt
+          </Typography>
+        </Box>
+      </Tooltip>
+    </Paper>
+  );
+});
+
+IliUnsupportedNode.displayName = 'IliUnsupportedNode';
+export default IliUnsupportedNode;

--- a/src/features/ili-explorer/components/nodes/index.ts
+++ b/src/features/ili-explorer/components/nodes/index.ts
@@ -9,3 +9,4 @@ export { IliUnloadedClassNode } from './IliUnloadedClassNode';
 export { IliTopicLabelNode } from './IliTopicLabelNode';
 export { IliTopicFrameNode } from './IliTopicFrameNode';
 export { IliPreviewNode } from './IliPreviewNode';
+export { IliUnsupportedNode } from './IliUnsupportedNode';

--- a/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
+++ b/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
@@ -111,12 +111,12 @@ export const ModelInfoPanel: React.FC<ModelInfoPanelProps> = ({
             {associationCount > 0 && <Chip size="small" label={`${associationCount} Assoc.`} />}
             {enumCount > 0 && (
               <Tooltip title="Wiederverwendbare Enumeration als Wertebereich (INTERLIS-Regel DomainDef, Refhb 3.8.2)">
-                <Chip size="small" label={`${enumCount} Enumeration`} />
+                <Chip size="small" label={`${enumCount} Enums`} />
               </Tooltip>
             )}
             {inlineEnumCount > 0 && (
               <Tooltip title="Anonyme Enumeration direkt als Attribut-Typ (INTERLIS-Regel AttrTypeDef, Refhb 3.6)">
-                <Chip size="small" label={`${inlineEnumCount} Inline-Enumeration`} />
+                <Chip size="small" label={`${inlineEnumCount} Enums (Inline)`} />
               </Tooltip>
             )}
             {unitCount > 0 && <Chip size="small" label={`${unitCount} Units`} />}

--- a/src/features/ili-explorer/components/toolbar/IliToolbar.tsx
+++ b/src/features/ili-explorer/components/toolbar/IliToolbar.tsx
@@ -97,8 +97,10 @@ export const IliToolbar: React.FC<IliToolbarProps> = ({
  
   const sortedOptions = [...searchOptions].sort((a, b) => {
     if (a.category !== b.category) {
-      const categoryOrder = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Attributes'];
-      return categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category);
+      const categoryOrder = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Associations', 'Attributes'];
+      const ai = categoryOrder.indexOf(a.category);
+      const bi = categoryOrder.indexOf(b.category);
+      return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
     }
     return a.label.localeCompare(b.label);
   });

--- a/src/features/ili-explorer/services/flowMapping.ts
+++ b/src/features/ili-explorer/services/flowMapping.ts
@@ -10,6 +10,8 @@ const FLOW_NODE_TYPE: Record<string, string> = {
   ASSOCIATION: 'associationNode',
   ENUMERATION: 'enumNode',
   UNIT: 'domainEnumNode',
+  FUNCTION: 'unsupportedNode',
+  VIEW: 'unsupportedNode',
   enumNode: 'enumNode',
   domainEnumNode: 'domainEnumNode',
 };
@@ -18,7 +20,7 @@ export function flowNodeFromBaseNode(node: IliBaseNode) {
   const { data: nodeData, ...nodeRest } = node;
   return {
     id: node.id,
-    type: FLOW_NODE_TYPE[node.type] ?? 'classNode',
+    type: FLOW_NODE_TYPE[node.type] ?? 'unsupportedNode',
     position: { x: 0, y: 0 },
     draggable: true,
     data: {

--- a/src/features/ili-explorer/services/layout/__tests__/getDirectRelations.test.ts
+++ b/src/features/ili-explorer/services/layout/__tests__/getDirectRelations.test.ts
@@ -29,7 +29,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const foo = flowNodes.find(n => n.id === 'Foo')!;
+    const foo = flowNodes.find(n => n.id === 'T.Foo')!;
 
     const result = getDirectRelations(
       foo,
@@ -40,7 +40,7 @@ describe('getDirectRelations', () => {
     );
 
     expect(result.nodes).toHaveLength(1);
-    expect(result.nodes[0].id).toBe('Foo');
+    expect(result.nodes[0].id).toBe('T.Foo');
     expect(result.nodes[0].data.isActive).toBe(true);
     expect(result.edges).toHaveLength(0);
   });
@@ -66,7 +66,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const mid = flowNodes.find(n => n.id === 'Mid')!;
+    const mid = flowNodes.find(n => n.id === 'T.Mid')!;
 
     const result = getDirectRelations(
       mid,
@@ -77,15 +77,15 @@ describe('getDirectRelations', () => {
     );
 
     const ids = result.nodes.map(n => n.id);
-    expect(ids).toContain('Mid');
-    expect(ids).toContain('Base');
-    expect(ids).toContain('LeafA');
-    expect(ids).toContain('LeafB');
+    expect(ids).toContain('T.Mid');
+    expect(ids).toContain('T.Base');
+    expect(ids).toContain('T.LeafA');
+    expect(ids).toContain('T.LeafB');
 
     const yOf = (id: string) => result.nodes.find(n => n.id === id)!.position.y;
-    expect(yOf('Base')).toBeLessThan(yOf('Mid'));
-    expect(yOf('LeafA')).toBeGreaterThan(yOf('Mid'));
-    expect(yOf('LeafB')).toBeGreaterThan(yOf('Mid'));
+    expect(yOf('T.Base')).toBeLessThan(yOf('T.Mid'));
+    expect(yOf('T.LeafA')).toBeGreaterThan(yOf('T.Mid'));
+    expect(yOf('T.LeafB')).toBeGreaterThan(yOf('T.Mid'));
   });
 
   it('attaches association nodes when showAssociations is true', () => {
@@ -107,7 +107,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const owner = flowNodes.find(n => n.id === 'Owner')!;
+    const owner = flowNodes.find(n => n.id === 'T.Owner')!;
 
     const result = getDirectRelations(
       owner,
@@ -141,7 +141,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const owner = flowNodes.find(n => n.id === 'Owner')!;
+    const owner = flowNodes.find(n => n.id === 'T.Owner')!;
 
     const result = getDirectRelations(
       owner,
@@ -169,7 +169,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const sub = flowNodes.find(n => n.id === 'Sub')!;
+    const sub = flowNodes.find(n => n.id === 'T.Sub')!;
 
     const a = getDirectRelations(sub, flowNodes, flowEdges, mockColors, defaultLayoutOptions);
     const b = getDirectRelations(sub, flowNodes, flowEdges, mockColors, defaultLayoutOptions);
@@ -230,7 +230,7 @@ describe('getDirectRelations', () => {
     `;
 
     const { flowNodes, flowEdges } = buildLayoutInput(ili);
-    const foo = flowNodes.find(n => n.id === 'Foo')!;
+    const foo = flowNodes.find(n => n.id === 'T.Foo')!;
 
     const result = getDirectRelations(
       foo,
@@ -242,7 +242,7 @@ describe('getDirectRelations', () => {
 
     const domainEdge = result.edges.find(e => e.target === 'domain_Status');
     expect(domainEdge).toBeDefined();
-    expect(domainEdge?.source).toBe('Foo');
+    expect(domainEdge?.source).toBe('T.Foo');
   });
 
   it('returns empty result for falsy entity / nodes / edges', () => {

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -11,14 +11,8 @@ export function layoutAssociationCenter(
 ): { nodes: IliNode[]; edges: Edge[] } | null {
   const association = entity.data.association as IliAssociation;
 
-  const sourceClass = allNodes.find(n =>
-    n.data.label === association.sourceClass ||
-    n.data.label === association.sourceClass.split('.').pop(),
-  );
-  const targetClass = allNodes.find(n =>
-    n.data.label === association.targetClass ||
-    n.data.label === association.targetClass.split('.').pop(),
-  );
+  const sourceClass = allNodes.find(n => n.id === association.sourceClass);
+  const targetClass = allNodes.find(n => n.id === association.targetClass);
 
   const unloadedSourceNode: IliNode | null = !sourceClass
     ? {
@@ -117,8 +111,8 @@ export function attachClassAssociations(
   if (!associations || associations.length === 0) return;
 
   const sortedAssociations = [...associations].sort((a, b) => {
-    const aIsSource = a.sourceClass === entity.data.label;
-    const bIsSource = b.sourceClass === entity.data.label;
+    const aIsSource = a.sourceClass === entity.id;
+    const bIsSource = b.sourceClass === entity.id;
     return Number(aIsSource) - Number(bIsSource);
   });
 
@@ -134,7 +128,7 @@ export function attachClassAssociations(
   const startY = activeNodeY - totalHeight / 2;
 
   sortedAssociations.forEach((assoc, index) => {
-    const isSource = assoc.sourceClass === entity.data.label;
+    const isSource = assoc.sourceClass === entity.id;
     const associationNodeId = `assoc_${assoc.name}_${entity.id}`;
 
     const associationNode: IliNode = {

--- a/src/features/ili-explorer/services/layout/overviewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/overviewStrategy.ts
@@ -1,4 +1,4 @@
-import { Edge } from '@xyflow/react';
+import { Edge, MarkerType } from '@xyflow/react';
 import type { IliNode, IliRelation } from '../types/IliBaseTypes';
 
 const COL_W = 460;
@@ -61,6 +61,7 @@ export function layoutModelOverview(
 
   const totalGridWidth = MAX_COLS * COL_W;
   const placedNodes: IliNode[] = [];
+  const topicLabelIdByName = new Map<string, string>();
   let cursorY = 0;
   let topicIndex = 0;
 
@@ -69,7 +70,6 @@ export function layoutModelOverview(
     const rows = Math.max(1, Math.ceil(classes.length / MAX_COLS));
     const groupContentH = TOPIC_HEADER_H + rows * ROW_H;
 
-    // Frame must be pushed first so it renders behind the cards.
     placedNodes.push({
       id: `__topic_frame_${topic}_${topicIndex}`,
       type: 'topicFrameNode',
@@ -84,8 +84,10 @@ export function layoutModelOverview(
       },
     } as unknown as IliNode);
 
+    const labelId = `__topic_label_${topic}_${topicIndex}`;
+    topicLabelIdByName.set(topic, labelId);
     placedNodes.push({
-      id: `__topic_label_${topic}_${topicIndex}`,
+      id: labelId,
       type: 'topicLabelNode',
       position: { x: 0, y: cursorY },
       draggable: false,
@@ -119,5 +121,25 @@ export function layoutModelOverview(
     topicIndex++;
   }
 
-  return { nodes: placedNodes, edges: [] };
+  const dependsEdges: Edge[] = [];
+  for (const rel of allRelations) {
+    if (rel.type !== 'DEPENDS') continue;
+    const sourceId = topicLabelIdByName.get(rel.sourceId);
+    const targetId = topicLabelIdByName.get(rel.targetId);
+    if (!sourceId || !targetId) continue;
+    dependsEdges.push({
+      id: `depends-${rel.sourceId}-${rel.targetId}`,
+      source: sourceId,
+      target: targetId,
+      type: 'default',
+      animated: false,
+      style: { stroke: '#8888aa', strokeWidth: 2, strokeDasharray: '6 4' },
+      markerEnd: { type: MarkerType.Arrow, color: '#8888aa' },
+      label: 'DEPENDS ON',
+      labelStyle: { fill: '#8888aa', fontSize: 11, fontWeight: 600 },
+      labelBgStyle: { fill: 'transparent' },
+    });
+  }
+
+  return { nodes: placedNodes, edges: dependsEdges };
 }

--- a/src/features/ili-explorer/services/parser/IliParser.ts
+++ b/src/features/ili-explorer/services/parser/IliParser.ts
@@ -6,8 +6,13 @@ import type { IliParseResult, IliParseError } from './types';
 
 const LEADING_NOISE = /^(?:\s+|!![^\n]*\n?|\/\*[\s\S]*?\*\/)*/;
 
+export interface IliParserOptions {
+  strict?: boolean;
+}
+
 export class IliParser {
-  parseContent(content: string): IliParseResult {
+  parseContent(content: string, options: IliParserOptions = {}): IliParseResult {
+    if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1);
     const stripped = content.replace(LEADING_NOISE, '');
     if (/^TRANSFER\b/i.test(stripped)) {
       return {
@@ -18,6 +23,7 @@ export class IliParser {
           offset: 0,
           line: 1,
           column: 1,
+          severity: 'error',
         }],
       };
     }
@@ -31,6 +37,7 @@ export class IliParser {
         offset: lexErr.offset,
         line: lexErr.line,
         column: lexErr.column,
+        severity: 'error',
       });
     }
 
@@ -46,14 +53,19 @@ export class IliParser {
         offset: tok?.startOffset,
         line: tok?.startLine,
         column: tok?.startColumn,
+        severity: 'error',
       });
     }
 
     const ast = astVisitor.build(cst, commentBefore);
+    if (options.strict) {
+      for (const w of ast.warnings) errors.push({ ...w, severity: 'error' });
+    }
     return {
       nodes: ast.nodes,
       relations: ast.relations,
       errors,
+      warnings: ast.warnings,
       imports: ast.imports,
       interlisVersion: ast.interlisVersion,
     };

--- a/src/features/ili-explorer/services/parser/__tests__/IliParser.test.ts
+++ b/src/features/ili-explorer/services/parser/__tests__/IliParser.test.ts
@@ -19,6 +19,62 @@ describe('IliParser (Chevrotain backend)', () => {
     expect(r.relations).toEqual([]);
   });
 
+  it('tolerates UTF-8 BOM at start of file', () => {
+    const r = parse('﻿INTERLIS 2.4;\nMODEL Demo = END Demo.');
+    expect(r.errors).toEqual([]);
+    expect(r.interlisVersion).toBe('2.4');
+  });
+
+  it('two classes with same name in different topics stay separate (R1.1)', () => {
+    const r = parse(`INTERLIS 2.4;
+MODEL Demo =
+  TOPIC T1 =
+    CLASS Item =
+      id : MANDATORY TEXT*10;
+    END Item;
+  END T1;
+  TOPIC T2 =
+    CLASS Item =
+      code : MANDATORY TEXT*5;
+    END Item;
+  END T2;
+END Demo.`);
+    expect(r.errors).toEqual([]);
+    const items = r.nodes.filter(n => n.type === 'CLASS' && n.name === 'Item');
+    expect(items).toHaveLength(2);
+    expect(items.map(i => i.id).sort()).toEqual(['T1.Item', 'T2.Item']);
+    // distinct attribute schemas confirm they did not collapse
+    const t1Item = items.find(i => i.id === 'T1.Item') as IliClassNode;
+    const t2Item = items.find(i => i.id === 'T2.Item') as IliClassNode;
+    expect(t1Item.attributes?.[0].name).toBe('id');
+    expect(t2Item.attributes?.[0].name).toBe('code');
+  });
+
+  it('emits warning for non-binary ASSOCIATION; strict mode escalates to error', () => {
+    const src = `INTERLIS 2.4;
+MODEL M AT "x" VERSION "1" =
+  TOPIC T =
+    CLASS A = id : MANDATORY TEXT*10; END A;
+    CLASS B = id : MANDATORY TEXT*10; END B;
+    CLASS C = id : MANDATORY TEXT*10; END C;
+    ASSOCIATION ABC =
+      RefA -- {1} A;
+      RefB -- {1} B;
+      RefC -- {1} C;
+    END ABC;
+  END T;
+END M.`;
+    const lenient = new IliParser().parseContent(src);
+    expect(lenient.errors?.filter(e => e.severity !== 'warning')).toEqual([]);
+    expect(lenient.warnings?.length).toBeGreaterThan(0);
+    expect(lenient.warnings?.[0].message).toMatch(/ASSOCIATION 'ABC'/);
+
+    const strict = new IliParser().parseContent(src, { strict: true });
+    const hardErrors = strict.errors?.filter(e => e.severity === 'error') ?? [];
+    expect(hardErrors.length).toBeGreaterThan(0);
+    expect(hardErrors[0].message).toMatch(/ASSOCIATION 'ABC'/);
+  });
+
   it('skips !! line comments and /* block */ comments', () => {
     const r = parse(`
       !! header comment
@@ -104,8 +160,8 @@ describe('IliParser (Chevrotain backend)', () => {
     expect(sub.isAbstract).toBe(false);
 
     const inh = r.relations.find(rel => rel.type === 'EXTENDS');
-    expect(inh?.sourceId).toBe('Sub');
-    expect(inh?.targetId).toBe('Base');
+    expect(inh?.sourceId).toBe('T.Sub');
+    expect(inh?.targetId).toBe('T.Base');
   });
 
   it('keeps qualified superclass names like Topic.Class', () => {
@@ -123,9 +179,9 @@ describe('IliParser (Chevrotain backend)', () => {
         END T;
       END Demo.
     `);
-    const inh = r.relations.find(rel => rel.sourceId === 'Child');
+    const inh = r.relations.find(rel => rel.sourceId === 'T.Child');
     expect(inh).toBeDefined();
-    expect(inh?.targetId).toContain('Parent');
+    expect(inh?.targetId).toBe('OtherTopic.Parent');
   });
 
   it('parses basic attribute types (NUMERIC, BOOLEAN, DATE, DATETIME, MTEXT)', () => {
@@ -387,8 +443,8 @@ describe('IliParser (Chevrotain backend)', () => {
     expect(asset.associations).toHaveLength(1);
     const assoc = owner.associations?.[0];
     expect(assoc?.name).toBe('Owns');
-    expect(assoc?.sourceClass).toBe('Owner');
-    expect(assoc?.targetClass).toBe('Asset');
+    expect(assoc?.sourceClass).toBe('T.Owner');
+    expect(assoc?.targetClass).toBe('T.Asset');
     expect(assoc?.sourceCardinality).toBe('1');
     expect(assoc?.targetCardinality).toBe('0..*');
     expect(assoc?.sourceRole).toBe('owner');
@@ -929,12 +985,12 @@ describe('IliParser (Chevrotain backend)', () => {
       expect(ownerAttr?.isReference).toBe(true);
       expect(ownerAttr?.type).toBe('REFERENCE TO Owner');
 
-      const refRel = r.relations.find(rel => rel.type === 'REFERENCES' && rel.sourceId === 'Asset');
-      expect(refRel?.targetId).toBe('Owner');
+      const refRel = r.relations.find(rel => rel.type === 'REFERENCES' && rel.sourceId === 'T.Asset');
+      expect(refRel?.targetId).toBe('T.Owner');
       expect(refRel?.role).toBe('owner');
     });
 
-    it('REFERENCE TO with qualified target stripped to last segment in edge', () => {
+    it('REFERENCE TO with already-qualified target keeps full qualifier', () => {
       const r = parse(`
         MODEL Demo =
           TOPIC T =
@@ -946,7 +1002,7 @@ describe('IliParser (Chevrotain backend)', () => {
         END Demo.
       `);
       const refRel = r.relations.find(rel => rel.type === 'REFERENCES');
-      expect(refRel?.targetId).toBe('Foo');
+      expect(refRel?.targetId).toBe('External.Foo');
     });
 
     it('creates external node placeholders for EXTENDS targets in imported models', () => {
@@ -965,7 +1021,7 @@ describe('IliParser (Chevrotain backend)', () => {
       expect(ext?.data.isExternal).toBe(true);
       expect(ext?.data.externalSource).toBe('Imported');
 
-      const inh = r.relations.find(rel => rel.type === 'EXTENDS' && rel.sourceId === 'Local');
+      const inh = r.relations.find(rel => rel.type === 'EXTENDS' && rel.sourceId === 'T.Local');
       expect(inh?.targetId).toBe('Imported.Foreign');
     });
 

--- a/src/features/ili-explorer/services/parser/__tests__/universal.test.ts
+++ b/src/features/ili-explorer/services/parser/__tests__/universal.test.ts
@@ -205,6 +205,44 @@ describe('NG Phase 2 — datamodel feinheiten', () => {
     expect(r.errors).toEqual([]);
   });
 
+  it('ASSOCIATION yields a searchable node in state.nodes', () => {
+    const src = `INTERLIS 2.4;
+MODEL M AT "x" VERSION "1" =
+  TOPIC T =
+    CLASS A = id : MANDATORY TEXT*10; END A;
+    CLASS B = id : MANDATORY TEXT*10; END B;
+    ASSOCIATION AssocAB =
+      RefA -- {1} A;
+      RefB -- {1..*} B;
+    END AssocAB;
+  END T;
+END M.`;
+    const r = new IliParser().parseContent(src);
+    expect(r.errors).toEqual([]);
+    const assocNode = r.nodes.find(n => n.type === 'ASSOCIATION');
+    expect(assocNode).toBeDefined();
+    expect(assocNode?.id).toBe('T.assoc_AssocAB');
+    expect(assocNode?.name).toBe('AssocAB');
+    expect((assocNode?.data as any).association?.sourceClass).toBe('T.A');
+    expect((assocNode?.data as any).association?.targetClass).toBe('T.B');
+  });
+
+  it('TOPIC DEPENDS ON produces a DEPENDS relation', () => {
+    const src = `INTERLIS 2.4;
+MODEL M AT "x" VERSION "1" =
+  TOPIC T1 = END T1;
+  TOPIC T2 =
+    DEPENDS ON T1;
+  END T2;
+END M.`;
+    const r = new IliParser().parseContent(src);
+    expect(r.errors).toEqual([]);
+    const depends = r.relations.filter(re => re.type === 'DEPENDS');
+    expect(depends).toHaveLength(1);
+    expect(depends[0].sourceId).toBe('T2');
+    expect(depends[0].targetId).toBe('T1');
+  });
+
   // Regression: ISOS_V2.ili Zeile 536. FORMAT war als DomainDef-Variante
   // registriert, fehlte aber als attributeType-Alternative.
   it('FORMAT as inline attribute type (Refhb 3.8.6)', () => {

--- a/src/features/ili-explorer/services/parser/astBuilder.ts
+++ b/src/features/ili-explorer/services/parser/astBuilder.ts
@@ -3,7 +3,7 @@ import type {
   IliBaseNode, IliRelation, IliAttribute, IliEnumValue, IliAssociation,
 } from '../types/IliBaseTypes';
 import type { IliClassNode, IliStructureNode } from '../types/IliModelTypes';
-import type { IliImportRef } from './types';
+import type { IliImportRef, IliParseError } from './types';
 import { cstParserInstance } from './cstParser';
 
 const BaseVisitor = cstParserInstance.getBaseCstVisitorConstructorWithDefaults();
@@ -17,10 +17,19 @@ interface VisitState {
   domainEnumsByName: Map<string, IliEnumValue[]>;
   parsedAssociations: IliAssociation[];
   pendingReferences: { sourceClass: string; targetQualified: string; attrName: string; isExternal: boolean }[];
+  warnings: IliParseError[];
 }
 
 function lastSegment(qualified: string): string {
   return qualified.includes('.') ? qualified.split('.').pop()! : qualified;
+}
+
+function qualifyLocal(localName: string, topicName: string): string {
+  return topicName ? `${topicName}.${localName}` : localName;
+}
+
+function qualifyRef(rawRef: string, currentTopic: string): string {
+  return rawRef.includes('.') ? rawRef : qualifyLocal(rawRef, currentTopic);
 }
 
 function imageOf(token: IToken | undefined): string {
@@ -66,7 +75,7 @@ class IliCstToAstVisitor extends BaseVisitor {
   private state: VisitState = {
     topicName: '', nodes: [], relations: [], imports: [], interlisVersion: undefined,
     domainEnumsByName: new Map(), parsedAssociations: [],
-    pendingReferences: [],
+    pendingReferences: [], warnings: [],
   };
   private commentBefore: Map<number, IToken[]> = new Map();
 
@@ -78,11 +87,11 @@ class IliCstToAstVisitor extends BaseVisitor {
   build(
     cst: CstNode,
     commentBefore: Map<number, IToken[]> = new Map(),
-  ): { nodes: IliBaseNode[]; relations: IliRelation[]; imports: IliImportRef[]; interlisVersion: string | undefined } {
+  ): { nodes: IliBaseNode[]; relations: IliRelation[]; imports: IliImportRef[]; interlisVersion: string | undefined; warnings: IliParseError[] } {
     this.state = {
       topicName: '', nodes: [], relations: [], imports: [], interlisVersion: undefined,
       domainEnumsByName: new Map(), parsedAssociations: [],
-      pendingReferences: [],
+      pendingReferences: [], warnings: [],
     };
     this.commentBefore = commentBefore;
     this.visit(cst);
@@ -96,7 +105,18 @@ class IliCstToAstVisitor extends BaseVisitor {
       relations: this.state.relations,
       imports: this.state.imports,
       interlisVersion: this.state.interlisVersion,
+      warnings: this.state.warnings,
     };
+  }
+
+  private emitWarning(message: string, token?: IToken): void {
+    this.state.warnings.push({
+      message,
+      severity: 'warning',
+      offset: token?.startOffset,
+      line: token?.startLine,
+      column: token?.startColumn,
+    });
   }
 
   private decorateExternalNodes(): void {
@@ -127,11 +147,10 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   private decorateReferences(): void {
     for (const ref of this.state.pendingReferences) {
-      const targetLocal = lastSegment(ref.targetQualified);
       this.state.relations.push({
-        id: `${ref.sourceClass}-${ref.attrName}-${targetLocal}-ref`,
+        id: `${ref.sourceClass}-${ref.attrName}-${ref.targetQualified}-ref`,
         sourceId: ref.sourceClass,
-        targetId: targetLocal,
+        targetId: ref.targetQualified,
         type: 'REFERENCES',
         role: ref.attrName,
       });
@@ -148,31 +167,28 @@ class IliCstToAstVisitor extends BaseVisitor {
   }
 
   private decorateInheritedAttributes(): void {
-    const classByName = new Map<string, IliClassNode>();
+    const classById = new Map<string, IliClassNode>();
     for (const node of this.state.nodes) {
       if (node.type === 'CLASS' || node.type === 'STRUCTURE') {
-        classByName.set(node.name, node as IliClassNode);
+        classById.set(node.id, node as IliClassNode);
       }
     }
 
     const superTypeOf = new Map<string, string>();
     for (const rel of this.state.relations) {
-      if (rel.type === 'EXTENDS') {
-        const targetLocal = lastSegment(rel.targetId);
-        superTypeOf.set(rel.sourceId, targetLocal);
-      }
+      if (rel.type === 'EXTENDS') superTypeOf.set(rel.sourceId, rel.targetId);
     }
 
-    for (const [className, classNode] of classByName) {
+    for (const [classId, classNode] of classById) {
       const inherited: { className: string; attributes: IliAttribute[] }[] = [];
-      const visited = new Set<string>([className]);
-      let current = superTypeOf.get(className);
+      const visited = new Set<string>([classId]);
+      let current = superTypeOf.get(classId);
       while (current && !visited.has(current)) {
         visited.add(current);
-        const ancestor = classByName.get(current);
+        const ancestor = classById.get(current);
         if (!ancestor) break;
         if (ancestor.attributes && ancestor.attributes.length > 0) {
-          inherited.push({ className: current, attributes: ancestor.attributes });
+          inherited.push({ className: ancestor.name, attributes: ancestor.attributes });
         }
         current = superTypeOf.get(current);
       }
@@ -184,10 +200,10 @@ class IliCstToAstVisitor extends BaseVisitor {
   private decorateAssociations(): void {
     this.state.parsedAssociations.forEach(assoc => {
       const sourceNode = this.state.nodes.find(
-        n => n.type === 'CLASS' && n.name === assoc.sourceClass,
+        n => n.type === 'CLASS' && n.id === assoc.sourceClass,
       ) as IliClassNode | undefined;
       const targetNode = this.state.nodes.find(
-        n => n.type === 'CLASS' && n.name === assoc.targetClass,
+        n => n.type === 'CLASS' && n.id === assoc.targetClass,
       ) as IliClassNode | undefined;
       // Self-Assoc nur einmal anhängen — sonst rendert die UI zwei Edges
       // mit identischer Key und React Flow erzeugt Geister-Edges.
@@ -200,6 +216,24 @@ class IliCstToAstVisitor extends BaseVisitor {
         targetNode.associations = [...(targetNode.associations ?? []), assoc];
         targetNode.data.associations = targetNode.associations;
       }
+
+      // Suchbarkeit: synthetischer ASSOCIATION-Node, damit `generateSearchOptions`
+      // den Assoc-Namen findet. Layout zentriert ihn via `layoutAssociationCenter`.
+      const topic = (sourceNode?.topicId as string | undefined) ?? (targetNode?.topicId as string | undefined) ?? '';
+      this.state.nodes.push({
+        id: assoc.id,
+        type: 'ASSOCIATION',
+        name: assoc.name,
+        position: { x: 0, y: 0 },
+        data: {
+          label: assoc.name,
+          association: assoc,
+          topic,
+          comment: assoc.comment,
+          isHighlighted: false,
+          isActive: false,
+        },
+      });
     });
   }
 
@@ -266,6 +300,7 @@ class IliCstToAstVisitor extends BaseVisitor {
   topicDef(ctx: any) {
     const topicName = imageOf(ctx.topicName?.[0]);
     this.state.topicName = topicName;
+    if (ctx.dependsOnDecl) ctx.dependsOnDecl.forEach((d: CstNode) => this.visit(d));
     if (ctx.domainSection) ctx.domainSection.forEach((d: CstNode) => this.visit(d));
     if (ctx.classDef) ctx.classDef.forEach((c: CstNode) => this.visit(c));
     if (ctx.structureDef) ctx.structureDef.forEach((s: CstNode) => this.visit(s));
@@ -274,6 +309,23 @@ class IliCstToAstVisitor extends BaseVisitor {
     if (ctx.functionDef) ctx.functionDef.forEach((f: CstNode) => this.visit(f));
     if (ctx.viewDef) ctx.viewDef.forEach((v: CstNode) => this.visit(v));
     this.state.topicName = '';
+  }
+
+  dependsOnDecl(ctx: any) {
+    if (!this.state.topicName) return;
+    const sourceTopic = this.state.topicName;
+    const qualifiedNames = (ctx.qualifiedName as CstNode[] | undefined) ?? [];
+    for (const qn of qualifiedNames) {
+      const target = this.visit(qn) as string;
+      if (!target) continue;
+      const targetLocal = lastSegment(target);
+      this.state.relations.push({
+        id: `depends_${sourceTopic}_${targetLocal}`,
+        sourceId: sourceTopic,
+        targetId: targetLocal,
+        type: 'DEPENDS',
+      });
+    }
   }
 
   functionDef(ctx: any) {
@@ -331,10 +383,11 @@ class IliCstToAstVisitor extends BaseVisitor {
 
     if (formation) {
       for (const src of formation.sources) {
+        const targetId = qualifyRef(src, this.state.topicName);
         this.state.relations.push({
-          id: `view_${viewName}-uses-${src}`,
+          id: `view_${viewName}-uses-${targetId}`,
           sourceId: `view_${viewName}`,
-          targetId: lastSegment(src),
+          targetId,
           type: 'REFERENCES',
           role: formation.kind.toLowerCase(),
         });
@@ -365,6 +418,7 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   structureDef(ctx: any) {
     const structName = imageOf(ctx.structName?.[0]);
+    const structId = qualifyLocal(structName, this.state.topicName);
     const isAbstract = !!ctx.classModifier;
     const comment = this.commentFor(ctx.Structure?.[0]);
 
@@ -384,7 +438,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
 
     const node: IliStructureNode = {
-      id: structName,
+      id: structId,
       type: 'STRUCTURE',
       name: structName,
       isAbstract,
@@ -404,10 +458,11 @@ class IliCstToAstVisitor extends BaseVisitor {
     this.state.nodes.push(node);
 
     if (superTypeQualified) {
+      const targetId = qualifyRef(superTypeQualified, this.state.topicName);
       this.state.relations.push({
-        id: `${structName}-${superTypeQualified}`,
-        sourceId: structName,
-        targetId: superTypeQualified,
+        id: `${structId}-${targetId}`,
+        sourceId: structId,
+        targetId,
         type: 'EXTENDS',
       });
     }
@@ -437,17 +492,26 @@ class IliCstToAstVisitor extends BaseVisitor {
     const roles = (ctx.roleDef as CstNode[] | undefined)?.map(
       r => this.visit(r) as { roleName: string; targetClass: string; cardinality: string },
     ) ?? [];
-    if (roles.length !== 2) return;
+    if (roles.length !== 2) {
+      this.emitWarning(
+        `ASSOCIATION '${assocName}' hat ${roles.length} Rollen — modvis unterstützt aktuell nur binäre Assoziationen (Roles=2). Verworfen.`,
+        ctx.assocName?.[0],
+      );
+      return;
+    }
     const [source, target] = roles;
+    const assocId = qualifyLocal(`assoc_${assocName}`, this.state.topicName);
+    const comment = this.commentFor(ctx.Association?.[0]) ?? this.commentFor(ctx.assocName?.[0]);
     const assoc: IliAssociation = {
-      id: `assoc_${assocName}`,
+      id: assocId,
       name: assocName,
-      sourceClass: lastSegment(source.targetClass),
-      targetClass: lastSegment(target.targetClass),
+      sourceClass: qualifyRef(source.targetClass, this.state.topicName),
+      targetClass: qualifyRef(target.targetClass, this.state.topicName),
       sourceRole: source.roleName.replace(/Ref$/, ''),
       targetRole: target.roleName.replace(/Ref$/, ''),
       sourceCardinality: source.cardinality,
       targetCardinality: target.cardinality,
+      comment,
     };
     this.state.parsedAssociations.push(assoc);
   }
@@ -610,6 +674,7 @@ class IliCstToAstVisitor extends BaseVisitor {
 
   classDef(ctx: any) {
     const className = imageOf(ctx.className?.[0]);
+    const classId = qualifyLocal(className, this.state.topicName);
     const isAbstract = !!ctx.classModifier;
     const comment = this.commentFor(ctx.Class?.[0]);
 
@@ -632,8 +697,8 @@ class IliCstToAstVisitor extends BaseVisitor {
       if (attr.isReference && attr.type.startsWith('REFERENCE TO ')) {
         const target = attr.type.slice('REFERENCE TO '.length).trim();
         this.state.pendingReferences.push({
-          sourceClass: className,
-          targetQualified: target,
+          sourceClass: classId,
+          targetQualified: qualifyRef(target, this.state.topicName),
           attrName: attr.name,
           isExternal: target.includes('.'),
         });
@@ -641,7 +706,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
 
     const node: IliClassNode = {
-      id: className,
+      id: classId,
       type: 'CLASS',
       name: className,
       isAbstract,
@@ -666,10 +731,11 @@ class IliCstToAstVisitor extends BaseVisitor {
     this.state.nodes.push(node);
 
     if (superTypeQualified) {
+      const targetId = qualifyRef(superTypeQualified, this.state.topicName);
       this.state.relations.push({
-        id: `${className}-${superTypeQualified}`,
-        sourceId: className,
-        targetId: superTypeQualified,
+        id: `${classId}-${targetId}`,
+        sourceId: classId,
+        targetId,
         type: 'EXTENDS',
       });
     }
@@ -733,6 +799,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
     if (ctx.formatType) return { type: this.visit(ctx.formatType[0]) as string };
     if (ctx.qualifiedName) return { type: this.visit(ctx.qualifiedName[0]) as string };
+    this.emitWarning('attributeType: keine Variante matched, Typ leer');
     return { type: '' };
   }
 

--- a/src/features/ili-explorer/services/parser/types.ts
+++ b/src/features/ili-explorer/services/parser/types.ts
@@ -5,6 +5,7 @@ export interface IliParseError {
   offset?: number;
   line?: number;
   column?: number;
+  severity?: 'error' | 'warning';
 }
 
 export interface IliImportRef {
@@ -16,6 +17,7 @@ export interface IliParseResult {
   nodes: IliBaseNode[];
   relations: IliRelation[];
   errors?: IliParseError[];
+  warnings?: IliParseError[];
   imports?: IliImportRef[];
   interlisVersion?: string;
 }

--- a/src/features/ili-explorer/services/searchOptions.ts
+++ b/src/features/ili-explorer/services/searchOptions.ts
@@ -1,8 +1,8 @@
 import { IliBaseNode, SearchOption } from './types/IliBaseTypes';
 import { IliClassNode } from './types/IliModelTypes';
 
-const VALID_NODE_TYPES = ['CLASS', 'STRUCTURE', 'TOPIC', 'ENUMERATION'] as const;
-const CATEGORY_ORDER = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Attributes'] as const;
+const VALID_NODE_TYPES = ['CLASS', 'STRUCTURE', 'TOPIC', 'ENUMERATION', 'ASSOCIATION'] as const;
+const CATEGORY_ORDER = ['Classes', 'Topics', 'Structures', 'Enumerations', 'Associations', 'Attributes'] as const;
 
 function categoryFor(nodeType: string): string {
   switch (nodeType) {
@@ -12,6 +12,8 @@ function categoryFor(nodeType: string): string {
       return 'Structures';
     case 'TOPIC':
       return 'Topics';
+    case 'ASSOCIATION':
+      return 'Associations';
     default:
       return 'Enumerations';
   }

--- a/src/features/ili-explorer/services/types/IliBaseTypes.ts
+++ b/src/features/ili-explorer/services/types/IliBaseTypes.ts
@@ -67,6 +67,7 @@ export interface IliAssociation {
   targetRole?: string;
   sourceCardinality?: string;
   targetCardinality?: string;
+  comment?: string;
 }
 
 export interface IliBaseNodeData {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+declare const __SOURCE_REPO__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,12 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string };
+const sourceRepo = process.env.VITE_SOURCE_REPO ?? 'https://github.com/mvnkoo/modvis';
 
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __SOURCE_REPO__: JSON.stringify(sourceRepo),
   },
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
- Qualified IDs: classes/structures/associations/relations now use `Topic.Class` IDs; resolves collisions between same-named classes in different topics. Layout (`associationStrategy`) compares on `entity.id` so association arrow direction works again.
- Parser: UTF-8 BOM stripping, `DEPENDS ON` edges rendered in overview, `FORMAT` as inline AttrType, diagnostics channel + `strict` mode for non-binary associations and unhandled attribute types. Association nodes carry comments and live in `state.nodes` → searchable.
- UI: `FUNCTION`/`VIEW` fall to `unsupportedNode` instead of silently rendering as classes; association tooltip always shows source/target + cardinalities; ModelInfoPanel chips compacted (`Enums`, `Enums (Inline)`), Classes shown first in search; AGPL source-code link moved into Settings menu pointing at `main`.
- Security: CSP tightened in `public/_headers` (no `unsafe-inline` for scripts, deprecated `X-XSS-Protection` removed).
- 129/129 tests green, typecheck + vite build clean.