### PR TITLE
feat(parser+ui): refhb conformance — structures, references, restriction

### DIFF
--- a/src/common/theme/ThemeContext.tsx
+++ b/src/common/theme/ThemeContext.tsx
@@ -34,6 +34,7 @@ export interface ThemeColors {
   shadow: string;
   relationship: string;
   reference: string;
+  containment: string;
   selectedNodeBg: string;
   nodeHeaderText: string;
 }
@@ -79,6 +80,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
     reference: '#ff4081',       // Pink wie typeNode
+    containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
     
     // Explorer Node Farben (Hintergrund)
     nodeSection: (mode: string) => mode === 'dark' ? '#333333' : '#f5f5f5',
@@ -138,6 +140,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
     reference: '#ff4081',       // Pink wie typeNode
+    containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
 
     // Explorer Node Farben
     nodeSection: (mode: string) => mode === 'dark' ? '#333333' : '#f5f5f5',
@@ -197,6 +200,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
     reference: '#ff4081',       // Pink wie typeNode
+    containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
 
     // Explorer Node Farben
     nodeSection: (mode: string) => mode === 'dark' ? '#333333' : '#f5f5f5',

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -558,7 +558,7 @@ const Flow: React.FC = () => {
 
   const modelStats = useMemo(() => {
     let classCount = 0, associationCount = 0, enumCount = 0, unitCount = 0;
-    let inlineEnumCount = 0;
+    let inlineEnumCount = 0, structureCount = 0;
     const topics = new Set<string>();
     for (const n of allNodes) {
       const data = n.data as any;
@@ -572,7 +572,7 @@ const Flow: React.FC = () => {
           if (data?.type === 'UNIT') unitCount++;
           else enumCount++;
           break;
-        case 'structureNode': break;
+        case 'structureNode': structureCount++; break;
       }
       // Inline-Enums leben als Attribut-Property auf CLASS/STRUCTURE-Knoten,
       // nicht als eigene Knoten — separat zählen für ehrliche Statistik.
@@ -581,7 +581,15 @@ const Flow: React.FC = () => {
         for (const a of attrs) if (a.isInlineEnum) inlineEnumCount++;
       }
     }
-    return { classCount, topicCount: topics.size, associationCount, enumCount, inlineEnumCount, unitCount };
+    return {
+      classCount,
+      structureCount,
+      topicCount: topics.size,
+      associationCount,
+      enumCount,
+      inlineEnumCount,
+      unitCount,
+    };
   }, [allNodes]);
 
   const lastLoadedFileRef = useRef<string | null>(null);
@@ -716,6 +724,7 @@ const Flow: React.FC = () => {
           <ModelInfoPanel
             fileName={currentFileName}
             classCount={modelStats.classCount}
+            structureCount={modelStats.structureCount}
             topicCount={modelStats.topicCount}
             associationCount={modelStats.associationCount}
             enumCount={modelStats.enumCount}

--- a/src/features/ili-explorer/components/legend/IliLegend.tsx
+++ b/src/features/ili-explorer/components/legend/IliLegend.tsx
@@ -37,7 +37,7 @@ const IliLegend: React.FC<IliLegendProps> = ({
     { label: 'TOPIC', color: colors.abstractEntity },
     { label: 'CLASS', color: colors.inheritance },
     { label: 'ABSTRACT CLASS', color: colors.abstractEntity },
-    { label: 'STRUCTURE', color: colors.typeNode },
+    { label: 'STRUCTURE', color: colors.containment },
     { 
       label: 'ENUMERATION', 
       color: colors.typeNode,
@@ -63,9 +63,11 @@ const IliLegend: React.FC<IliLegendProps> = ({
     { label: 'EXTENDS', color: colors.inheritance, style: 'solid' },
     { label: 'DEPENDS ON', color: colors.relationship, style: 'dashed' },
     { label: 'ASSOCIATES', color: colors.reference, style: 'dotted' },
-    { 
-      label: 'ENUMERATION', 
-      color: colors.typeReference, 
+    { label: 'REFERENCES', color: colors.reference, style: 'dashed' },
+    { label: 'CONTAINS', color: colors.containment, style: 'solid' },
+    {
+      label: 'ENUMERATION',
+      color: colors.typeReference,
       style: 'dashed',
       isDisabled: !enumsVisible
     }

--- a/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
@@ -158,7 +158,10 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
               {getShortClassName(data.association.sourceClass)}
               {data.association.sourceCardinality && ` [${data.association.sourceCardinality}]`}
               {' — '}
-              {getShortClassName(data.association.targetClass)}
+              {[
+                data.association.targetClass,
+                ...(data.association.targetAlternatives ?? []),
+              ].map(getShortClassName).join(' | ')}
               {data.association.targetCardinality && ` [${data.association.targetCardinality}]`}
             </Typography>
           </Box>
@@ -188,7 +191,9 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
           overflow: 'hidden'
         }}>
           <Typography variant="subtitle2" fontWeight="bold">
-            «ASSOCIATION»
+            {data.association.kind === 'composition' ? '«COMPOSITION»'
+              : data.association.kind === 'aggregation' ? '«AGGREGATION»'
+              : '«ASSOCIATION»'}
           </Typography>
           <Typography variant="subtitle1" fontWeight="bold">
             {data.association.name}
@@ -348,20 +353,23 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
                 alignItems: 'start'
               }}>
                 <Box>
-                  <Typography 
+                  <Typography
                     variant="body2"
                     color={colors.propertyText}
-                    sx={{ 
+                    sx={{
                       fontFamily: 'monospace',
                       wordBreak: 'break-word',
                       whiteSpace: 'pre-wrap'
                     }}
                   >
-                    {getShortClassName(data.association.targetClass)}
+                    {[
+                      data.association.targetClass,
+                      ...(data.association.targetAlternatives ?? []),
+                    ].map(getShortClassName).join(' | ')}
                   </Typography>
                   {data.association.targetRole && (
-                    <Typography 
-                      variant="body2" 
+                    <Typography
+                      variant="body2"
                       color="text.secondary"
                       sx={{ mt: 0.5 }}
                     >

--- a/src/features/ili-explorer/components/nodes/IliClassNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliClassNode.tsx
@@ -108,13 +108,25 @@ const AttributeRow: React.FC<AttributeRowProps> = memo(({ attribute }) => {
 
       {!attribute.isEnum && !attribute.isDomainEnum && attribute.type.includes('..') && (
         <Box sx={{ mt: attribute.comment ? 1 : 0 }}>
-          <Typography variant="caption" sx={{ 
-            fontWeight: 'bold', 
+          <Typography variant="caption" sx={{
+            fontWeight: 'bold',
             display: 'block',
             fontFamily: 'monospace'
           }}>
             {attribute.type}
           </Typography>
+        </Box>
+      )}
+      {attribute.restriction && attribute.restriction.length > 0 && (
+        <Box sx={{ mt: attribute.comment ? 1 : 0 }}>
+          <Typography variant="caption" sx={{ display: 'block', fontWeight: 600 }}>
+            RESTRICTION:
+          </Typography>
+          {attribute.restriction.map((r, i) => (
+            <Typography key={i} variant="caption" sx={{ display: 'block', fontFamily: 'monospace', ml: 1 }}>
+              • {r}
+            </Typography>
+          ))}
         </Box>
       )}
     </Box>
@@ -186,11 +198,15 @@ const AttributeRow: React.FC<AttributeRowProps> = memo(({ attribute }) => {
           }
         }}
       >
-        <Typography 
-          sx={{ 
+        <Typography
+          sx={{
             fontFamily: 'monospace',
             fontSize: '0.75rem',
-            color: attribute.isEnum || attribute.isDomainEnum ? colors.typeReference : colors.propertyText,
+            color: attribute.isEnum || attribute.isDomainEnum
+              ? colors.typeReference
+              : attribute.isStructValue
+                ? colors.containment
+                : colors.propertyText,
             lineHeight: 1.4,
             cursor: 'help',
             wordBreak: 'break-word'

--- a/src/features/ili-explorer/components/nodes/IliStructureNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliStructureNode.tsx
@@ -1,12 +1,14 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useMemo, useState } from 'react';
 import { Handle, Position } from '@xyflow/react';
-import { 
-  Paper, 
-  Typography, 
-  Box, 
-  IconButton, 
-  Collapse 
+import {
+  Paper,
+  Typography,
+  Box,
+  IconButton,
+  Collapse,
+  Tooltip,
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { ExpandMore, ExpandLess } from '@mui/icons-material';
 import { useTheme } from '../../../../common/theme/ThemeContext';
 import { IliStructureNode as IliStructureNodeType } from '../../services/types/IliModelTypes';
@@ -17,6 +19,9 @@ interface StructureNodeProps {
     label: string;
     isHighlighted?: boolean;
     topicName?: string;
+    expanded?: boolean;
+    isExpanded?: boolean;
+    onExpandChange?: (expanded: boolean) => void;
   };
 }
 
@@ -26,10 +31,61 @@ interface AttributeRowProps {
 
 const AttributeRow: React.FC<AttributeRowProps> = memo(({ attribute }) => {
   const { colors } = useTheme();
-  
+
+  const tooltipContent = useMemo(() => (
+    <Box sx={{ p: 1, maxWidth: 400 }}>
+      {attribute.comment && (
+        <Typography variant="caption" sx={{
+          display: 'block',
+          whiteSpace: 'pre-wrap',
+          color: 'text.secondary'
+        }}>
+          {attribute.comment}
+        </Typography>
+      )}
+      {(attribute.isEnum || attribute.isDomainEnum) && attribute.enumValues && (
+        <Box sx={{ mt: attribute.comment ? 1 : 0 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold', display: 'block', mb: 0.5 }}>
+            Mögliche Werte:
+          </Typography>
+          {attribute.enumValues.map((enumValue, index) => (
+            <Box key={index} sx={{ ml: 1 }}>
+              <Typography variant="caption" sx={{ display: 'block', fontFamily: 'monospace' }}>
+                • {enumValue.value}
+                {enumValue.subValues?.map((subValue, subIndex) => (
+                  <Box key={`${index}-${subIndex}`} sx={{ ml: 2 }}>
+                    <Typography variant="caption" sx={{ display: 'block', fontFamily: 'monospace' }}>
+                      ∟ {subValue.value}
+                    </Typography>
+                  </Box>
+                ))}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+      {!attribute.isEnum && !attribute.isDomainEnum && attribute.type.includes('..') && (
+        <Box sx={{ mt: attribute.comment ? 1 : 0 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold', display: 'block', fontFamily: 'monospace' }}>
+            {attribute.type}
+          </Typography>
+        </Box>
+      )}
+      {attribute.isStructValue && (
+        <Typography variant="caption" sx={{
+          mt: attribute.comment ? 1 : 0,
+          display: 'block',
+          color: 'text.secondary',
+        }}>
+          Strukturattribut → {attribute.structRef}
+        </Typography>
+      )}
+    </Box>
+  ), [attribute]);
+
   return (
-    <Box sx={{ 
-      display: 'grid', 
+    <Box sx={{
+      display: 'grid',
       gridTemplateColumns: '24px minmax(100px, 1fr) minmax(100px, 1.2fr)',
       gap: 1,
       alignItems: 'start',
@@ -39,13 +95,13 @@ const AttributeRow: React.FC<AttributeRowProps> = memo(({ attribute }) => {
         bgcolor: 'action.hover'
       }
     }}>
-      <Box sx={{ 
-        display: 'flex', 
-        alignItems: 'center', 
+      <Box sx={{
+        display: 'flex',
+        alignItems: 'center',
         height: '100%',
         pt: 0.3
       }}>
-        <Box sx={{ 
+        <Box sx={{
           width: 6,
           height: 6,
           borderRadius: '50%',
@@ -55,55 +111,117 @@ const AttributeRow: React.FC<AttributeRowProps> = memo(({ attribute }) => {
           boxShadow: theme => `0 0 0 1px ${theme.palette.background.paper}`,
         }} />
       </Box>
-      <Typography 
-        sx={{ 
-          fontFamily: 'monospace',
-          fontSize: '0.75rem',
-          lineHeight: 1.4
+      <Tooltip
+        title={tooltipContent}
+        placement="left"
+        componentsProps={{
+          tooltip: {
+            sx: {
+              bgcolor: colors.paper,
+              color: colors.text,
+              boxShadow: colors.shadow,
+            },
+          },
         }}
       >
-        {attribute.name}
-      </Typography>
-      <Typography 
-        sx={{ 
-          fontFamily: 'monospace',
-          fontSize: '0.75rem',
-          color: attribute.isReference ? colors.typeReference : 'primary.main',
-          lineHeight: 1.4
+        <Typography
+          sx={{
+            fontFamily: 'monospace',
+            fontSize: '0.75rem',
+            lineHeight: 1.4,
+            cursor: 'help',
+            wordBreak: 'break-word',
+          }}
+        >
+          {attribute.name}
+        </Typography>
+      </Tooltip>
+      <Tooltip
+        title={tooltipContent}
+        placement="right"
+        componentsProps={{
+          tooltip: {
+            sx: {
+              bgcolor: colors.paper,
+              color: colors.text,
+              boxShadow: colors.shadow,
+            },
+          },
         }}
       >
-        {attribute.type}
-      </Typography>
+        <Typography
+          sx={{
+            fontFamily: 'monospace',
+            fontSize: '0.75rem',
+            color: attribute.isEnum || attribute.isDomainEnum
+              ? colors.typeReference
+              : attribute.isStructValue
+                ? colors.containment
+                : attribute.isReference
+                  ? colors.typeReference
+                  : colors.propertyText,
+            lineHeight: 1.4,
+            cursor: 'help',
+            wordBreak: 'break-word',
+          }}
+        >
+          {attribute.type}
+        </Typography>
+      </Tooltip>
     </Box>
   );
 });
 
 export const IliStructureNode: React.FC<StructureNodeProps> = memo(({ data }) => {
   const { colors } = useTheme();
-  const [expanded, setExpanded] = useState(false);
+  const [localExpanded, setLocalExpanded] = useState(false);
+  const expanded = data.expanded ?? data.isExpanded ?? localExpanded;
 
   const handleExpandClick = (event: React.MouseEvent) => {
     event.stopPropagation();
-    setExpanded(!expanded);
+    const next = !expanded;
+    setLocalExpanded(next);
+    data.onExpandChange?.(next);
   };
 
+  const dataAny = data as unknown as {
+    isAbstract?: boolean; isFinal?: boolean; isExtended?: boolean;
+    comment?: string; topic?: string;
+  };
+  const topicLabel = data.topicName ?? dataAny.topic;
+
+  const isActive = !!(data as unknown as { isActive?: boolean }).isActive;
+
   return (
-    <Paper 
+    <Paper
       elevation={2}
-      sx={{ 
+      sx={{
         width: 400,
-        border: data.isHighlighted 
-          ? `2px solid ${colors.selectedEntity}` 
-          : `2px solid ${colors.typeNode}`,
+        position: 'relative',
+        border: isActive
+          ? `2px solid ${colors.selectedEntity}`
+          : data.isHighlighted
+            ? `2px solid ${colors.selectedEntity}`
+            : `2px solid ${colors.containment}`,
         borderRadius: 2,
         overflow: 'hidden',
-        bgcolor: colors.background,
+        bgcolor: isActive ? colors.selectedNodeBg : colors.background,
         color: colors.text,
         cursor: 'pointer',
-        transition: 'all 0.2s ease-in-out',
+        transition: 'box-shadow 0.2s ease-in-out, background-color 1400ms ease-out, border-color 1400ms ease-out',
+        '& .ili-struct-header': {
+          transition: 'background-color 1400ms ease-out',
+        },
         '&:hover': {
-          boxShadow: theme => theme.shadows[8]
-        }
+          boxShadow: theme => theme.shadows[8],
+          ...(isActive ? {} : {
+            ...(expanded ? {} : { bgcolor: alpha(colors.selectedEntity, 0.18) }),
+            borderColor: colors.selectedEntity,
+            '& .ili-struct-header': {
+              bgcolor: colors.selectedEntity,
+            },
+          }),
+        },
       }}
     >
       <Handle
@@ -114,8 +232,20 @@ export const IliStructureNode: React.FC<StructureNodeProps> = memo(({ data }) =>
       />
       <Handle
         type="target"
+        position={Position.Top}
+        id="top-target"
+        style={{ opacity: 0 }}
+      />
+      <Handle
+        type="target"
         position={Position.Bottom}
         id="bottom"
+        style={{ opacity: 0 }}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom-source"
         style={{ opacity: 0 }}
       />
       <Handle
@@ -125,30 +255,81 @@ export const IliStructureNode: React.FC<StructureNodeProps> = memo(({ data }) =>
         style={{ opacity: 0 }}
       />
       <Handle
+        type="target"
+        position={Position.Left}
+        id="left-target"
+        style={{ opacity: 0 }}
+      />
+      <Handle
         type="source"
         position={Position.Right}
         id="right"
         style={{ opacity: 0 }}
       />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right-source"
+        style={{ opacity: 0 }}
+      />
 
-      <Box sx={{ 
-        bgcolor: data.isHighlighted ? colors.selectedEntity : colors.typeNode,
-        color: '#FFFFFF',
-        p: 1,
-        textAlign: 'center'
-      }}>
-        <Typography variant="subtitle2" fontWeight="bold">
-          «STRUCTURE»
-        </Typography>
-        <Typography variant="subtitle1" fontWeight="bold">
-          {data.label}
-        </Typography>
-        {data.topicName && (
-          <Typography variant="caption">
-            {data.topicName}.{data.label}
+      <Tooltip
+        title={
+          <Box sx={{ p: 1, maxWidth: 400 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 'bold', display: 'block', mb: 0.5, color: colors.text }}>
+              {data.label}
+              {dataAny.isAbstract && ' (Abstract)'}
+              {dataAny.isFinal && ' (Final)'}
+              {dataAny.isExtended && ' (Extended)'}
+            </Typography>
+            {dataAny.comment && (
+              <Typography variant="caption" sx={{ display: 'block', whiteSpace: 'pre-wrap', color: colors.text, opacity: 0.8, mb: 1 }}>
+                {dataAny.comment}
+              </Typography>
+            )}
+            <Typography variant="caption" sx={{ display: 'block', color: colors.text, opacity: 0.7 }}>
+              Struktur — wertgebunden, ohne eigene Identität (Refhb 3.5.3).
+            </Typography>
+            {topicLabel && (
+              <Typography variant="caption" sx={{ display: 'block', mt: 0.5, color: colors.text, opacity: 0.7, fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                {topicLabel}
+              </Typography>
+            )}
+          </Box>
+        }
+        placement="top"
+        enterDelay={500}
+        enterNextDelay={500}
+        leaveDelay={0}
+        componentsProps={{
+          tooltip: {
+            sx: {
+              bgcolor: colors.paper,
+              color: colors.text,
+              boxShadow: colors.shadow,
+            },
+          },
+        }}
+      >
+        <Box className="ili-struct-header" sx={{
+          bgcolor: isActive || data.isHighlighted ? colors.selectedEntity : colors.containment,
+          color: '#FFFFFF',
+          p: 1,
+          textAlign: 'center'
+        }}>
+          <Typography variant="subtitle2" fontWeight="bold">
+            «STRUCTURE»
           </Typography>
-        )}
-      </Box>
+          <Typography variant="subtitle1" fontWeight="bold">
+            {data.label}
+          </Typography>
+          {topicLabel && (
+            <Typography variant="caption">
+              {topicLabel}
+            </Typography>
+          )}
+        </Box>
+      </Tooltip>
 
       <Box sx={{ 
         p: 1,

--- a/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
+++ b/src/features/ili-explorer/components/sidebar/ModelInfoPanel.tsx
@@ -26,6 +26,7 @@ import type { IliImportRef } from '../../services/parser/types';
 interface ModelInfoPanelProps {
   fileName: string | null;
   classCount: number;
+  structureCount: number;
   topicCount: number;
   associationCount: number;
   enumCount: number;
@@ -41,6 +42,7 @@ const STD_LIBS = new Set(['INTERLIS', 'Units', 'Time', 'CoordSys']);
 export const ModelInfoPanel: React.FC<ModelInfoPanelProps> = ({
   fileName,
   classCount,
+  structureCount,
   topicCount,
   associationCount,
   enumCount,
@@ -107,6 +109,11 @@ export const ModelInfoPanel: React.FC<ModelInfoPanelProps> = ({
               <Chip size="small" color="primary" label={`INTERLIS ${interlisVersion}`} />
             )}
             <Chip size="small" label={`${classCount} Classes`} />
+            {structureCount > 0 && (
+              <Tooltip title="Wertgebundene Datenstrukturen ohne eigene Identität (Refhb 3.5/3.6 Structure)">
+                <Chip size="small" label={`${structureCount} Structures`} />
+              </Tooltip>
+            )}
             {topicCount > 0 && <Chip size="small" label={`${topicCount} Topics`} />}
             {associationCount > 0 && <Chip size="small" label={`${associationCount} Assoc.`} />}
             {enumCount > 0 && (

--- a/src/features/ili-explorer/hooks/useIliLoader.ts
+++ b/src/features/ili-explorer/hooks/useIliLoader.ts
@@ -4,7 +4,12 @@ import type { ThemeColors } from '../../../common/theme/ThemeContext';
 import { readFileAsText } from '../../../common/utils/readFileAsText';
 import { IliSchemaService } from '../services/iliSchemaService';
 import { generateSearchOptions } from '../services/searchOptions';
-import { flowNodeFromBaseNode, inheritanceEdgesFromRelations } from '../services/flowMapping';
+import {
+  flowNodeFromBaseNode,
+  inheritanceEdgesFromRelations,
+  referenceEdgesFromRelations,
+  containmentEdgesFromRelations,
+} from '../services/flowMapping';
 import type { IliRelation, SearchOption } from '../services/types/IliBaseTypes';
 import type { IliParseError, IliImportRef } from '../services/parser/types';
 
@@ -75,11 +80,23 @@ export function useIliLoader(options: UseIliLoaderOptions): UseIliLoaderReturn {
       const baseNodes = schemaServiceRef.current.getNodes();
       const parsedRelations = schemaServiceRef.current.getRelations();
       const flowNodes = baseNodes.map(flowNodeFromBaseNode);
-      const flowEdges = inheritanceEdgesFromRelations(
-        parsedRelations,
-        colorsRef.current,
-        useCurvedLinesRef.current
-      );
+      const flowEdges = [
+        ...inheritanceEdgesFromRelations(
+          parsedRelations,
+          colorsRef.current,
+          useCurvedLinesRef.current
+        ),
+        ...referenceEdgesFromRelations(
+          parsedRelations,
+          colorsRef.current,
+          useCurvedLinesRef.current
+        ),
+        ...containmentEdgesFromRelations(
+          parsedRelations,
+          colorsRef.current,
+          useCurvedLinesRef.current
+        ),
+      ];
 
       setParseWarnings(schemaServiceRef.current.getParseErrors());
       setImports(schemaServiceRef.current.getImports());

--- a/src/features/ili-explorer/services/flowMapping.ts
+++ b/src/features/ili-explorer/services/flowMapping.ts
@@ -47,10 +47,65 @@ export function inheritanceEdgesFromRelations(
       target: relation.targetId,
       type: useCurvedLines ? 'default' : 'step',
       animated: false,
+      data: { relationType: 'EXTENDS' },
       style: { stroke: colors.inheritance, strokeWidth: 2 },
       markerEnd: {
         type: MarkerType.Arrow,
         color: colors.inheritance,
+      },
+    }));
+}
+
+export function containmentEdgesFromRelations(
+  relations: IliRelation[],
+  colors: ThemeColors,
+  useCurvedLines: boolean,
+): Edge[] {
+  return relations
+    .filter(relation => relation.type === 'CONTAINS')
+    .map(relation => ({
+      id: relation.id,
+      source: relation.sourceId,
+      target: relation.targetId,
+      type: useCurvedLines ? 'default' : 'step',
+      animated: false,
+      label: relation.role,
+      data: { relationType: 'CONTAINS' },
+      style: { stroke: colors.containment, strokeWidth: 2 },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: colors.containment,
+        width: 18,
+        height: 18,
+      },
+    }));
+}
+
+export function referenceEdgesFromRelations(
+  relations: IliRelation[],
+  colors: ThemeColors,
+  useCurvedLines: boolean,
+): Edge[] {
+  return relations
+    .filter(relation => relation.type === 'REFERENCES')
+    .map(relation => ({
+      id: relation.id,
+      source: relation.sourceId,
+      target: relation.targetId,
+      type: useCurvedLines ? 'default' : 'step',
+      animated: false,
+      label: relation.role,
+      data: { relationType: 'REFERENCES' },
+      style: {
+        stroke: colors.reference,
+        strokeWidth: 2,
+        strokeDasharray: '5,5',
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: colors.reference,
+        width: 18,
+        height: 18,
       },
     }));
 }

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -151,21 +151,27 @@ export function attachClassAssociations(
     relatedNodeIds.add(associationNodeId);
     enhancedNodes.push(associationNode);
 
+    const kind = assoc.kind ?? 'plain';
+    const isStrong = kind === 'composition' || kind === 'aggregation';
+    const edgeStyle: Record<string, string | number> = {
+      stroke: colors.relationship,
+      strokeWidth: isStrong ? 3 : 2,
+      ...(isStrong ? {} : { strokeDasharray: '5,5' }),
+    };
+    const markerType = kind === 'composition'
+      ? MarkerType.ArrowClosed
+      : MarkerType.Arrow;
     enumEdges.push({
       id: `${entity.id}-${associationNodeId}-assoc`,
       source: isSource ? entity.id : associationNodeId,
       target: isSource ? associationNodeId : entity.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: true,
+      animated: !isStrong,
       sourceHandle: isSource ? 'left-source' : 'right-source',
       targetHandle: isSource ? 'right-target' : 'left-target',
-      style: {
-        stroke: colors.relationship,
-        strokeWidth: 2,
-        strokeDasharray: '5,5',
-      },
+      style: edgeStyle,
       markerEnd: {
-        type: MarkerType.Arrow,
+        type: markerType,
         color: colors.relationship,
         width: 20,
         height: 20,

--- a/src/features/ili-explorer/services/layout/getDirectRelations.ts
+++ b/src/features/ili-explorer/services/layout/getDirectRelations.ts
@@ -44,6 +44,10 @@ export function getDirectRelations(
   const superTypeChain = new Set<string>();
   const subTypeChain = new Set<string>();
   const enumTypes = new Set<string>();
+  const containedStructs = new Set<string>();
+  const structureOwners = new Set<string>();
+  const referenceTargets = new Set<string>();
+  const referenceSources = new Set<string>();
   const enumEdges: Edge[] = [];
   let enhancedNodes: IliNode[] = [];
 
@@ -93,12 +97,27 @@ export function getDirectRelations(
   );
 
   for (const edge of allEdges) {
-    if (edge.target === entity.id) {
-      const sourceNode = nodeMap.get(edge.source);
-      if (sourceNode) {
-        subTypeChain.add(edge.source);
-        relatedNodeIds.add(edge.source);
-      }
+    if (edge.target !== entity.id) continue;
+    const rt = (edge.data as { relationType?: string } | undefined)?.relationType;
+    if (rt !== undefined && rt !== 'EXTENDS') continue;
+    const sourceNode = nodeMap.get(edge.source);
+    if (sourceNode) {
+      subTypeChain.add(edge.source);
+      relatedNodeIds.add(edge.source);
+    }
+  }
+
+  for (const edge of allEdges) {
+    const rt = (edge.data as { relationType?: string } | undefined)?.relationType;
+    if (rt !== 'REFERENCES' && rt !== 'CONTAINS') continue;
+    if (edge.source === entity.id) {
+      relatedNodeIds.add(edge.target);
+      if (rt === 'CONTAINS') containedStructs.add(edge.target);
+      else if (rt === 'REFERENCES') referenceTargets.add(edge.target);
+    } else if (edge.target === entity.id) {
+      relatedNodeIds.add(edge.source);
+      if (rt === 'CONTAINS') structureOwners.add(edge.source);
+      else if (rt === 'REFERENCES') referenceSources.add(edge.source);
     }
   }
 
@@ -145,11 +164,44 @@ export function getDirectRelations(
       const isSuperType = superTypeChain.has(id);
       const isSubType = subTypeChain.has(id);
       const isEnum = enumTypes.has(id);
+      const isContainedStruct = containedStructs.has(id);
+      const isStructureOwner = structureOwners.has(id);
+      const isReferenceTarget = referenceTargets.has(id);
+      const isReferenceSource = referenceSources.has(id);
       const isClassUsingEnum = entity.type === 'enumNode' && originalNode.type === 'classNode';
+
+      const leftColumnOrder: string[] = [
+        ...Array.from(structureOwners),
+        ...Array.from(referenceSources),
+      ];
+      const rightColumnOrder: string[] = [
+        ...Array.from(referenceTargets),
+        ...Array.from(enumTypes),
+        ...Array.from(containedStructs),
+      ];
+      const sideSpacingY = useMagicLayout
+        ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.ENUM
+        : LAYOUT_CONFIG.ENUM.SPACING_Y;
+      const rightTotalHeight = (rightColumnOrder.length - 1) * sideSpacingY;
+      const rightStartY = -(rightTotalHeight / 2);
+      const rightIndex = rightColumnOrder.indexOf(id);
+      const leftTotalHeight = (leftColumnOrder.length - 1) * sideSpacingY;
+      const leftStartY = -(leftTotalHeight / 2);
+      const leftIndex = leftColumnOrder.indexOf(id);
 
       let position = { x: 0, y: 0 };
 
-      if (isClassUsingEnum) {
+      if (isStructureOwner || isReferenceSource) {
+        position = {
+          x: -LAYOUT_CONFIG.ENUM.OFFSET_X,
+          y: leftStartY + leftIndex * sideSpacingY,
+        };
+      } else if (isReferenceTarget || isContainedStruct) {
+        position = {
+          x: LAYOUT_CONFIG.ENUM.OFFSET_X,
+          y: rightStartY + rightIndex * sideSpacingY,
+        };
+      } else if (isClassUsingEnum) {
         const classArray = Array.from(relatedNodeIds).filter(nid => {
           const node = nodeMap.get(nid);
           return node && node.type === 'classNode';
@@ -167,17 +219,9 @@ export function getDirectRelations(
         if (entity.type === 'enumNode') {
           position = { x: 0, y: 0 };
         } else {
-          const enumArray = Array.from(enumTypes);
-          const index = enumArray.indexOf(id);
-          const totalEnums = enumArray.length;
-          const spacingY = useMagicLayout
-            ? LAYOUT_CONFIG.ENUM.SPACING_Y * LAYOUT_CONFIG.MAGIC.ENUM
-            : LAYOUT_CONFIG.ENUM.SPACING_Y;
-          const totalHeight = (totalEnums - 1) * spacingY;
-          const startY = -(totalHeight / 2);
           position = {
             x: LAYOUT_CONFIG.ENUM.OFFSET_X,
-            y: startY + index * spacingY,
+            y: rightStartY + rightIndex * sideSpacingY,
           };
         }
       } else if (isSuperType) {
@@ -198,14 +242,26 @@ export function getDirectRelations(
   const allEdgesResult: Edge[] = [
     ...allEdges
       .filter(edge => relatedNodeIds.has(edge.source) && relatedNodeIds.has(edge.target))
-      .map(edge => ({
-        ...edge,
-        type: useCurvedLines ? 'default' : 'step',
-        animated: false,
-        sourceHandle: 'top',
-        targetHandle: 'bottom',
-        style: { stroke: colors.inheritance, strokeWidth: 2 },
-      })),
+      .map(edge => {
+        const rt = (edge.data as { relationType?: string } | undefined)?.relationType;
+        if (rt === 'REFERENCES' || rt === 'CONTAINS') {
+          return {
+            ...edge,
+            type: useCurvedLines ? 'default' : 'step',
+            animated: false,
+            sourceHandle: 'right-source',
+            targetHandle: 'left-target',
+          };
+        }
+        return {
+          ...edge,
+          type: useCurvedLines ? 'default' : 'step',
+          animated: false,
+          sourceHandle: 'top',
+          targetHandle: 'bottom',
+          style: { stroke: colors.inheritance, strokeWidth: 2 },
+        };
+      }),
 
     ...enumEdges.filter(edge => edge.id.endsWith('-enum')).map(edge => ({
       ...edge,

--- a/src/features/ili-explorer/services/layout/hierarchyCollection.ts
+++ b/src/features/ili-explorer/services/layout/hierarchyCollection.ts
@@ -1,6 +1,11 @@
 import type { Edge } from '@xyflow/react';
 import type { IliNode } from '../types/IliBaseTypes';
 
+function isInheritanceEdge(edge: Edge): boolean {
+  const rt = (edge.data as { relationType?: string } | undefined)?.relationType;
+  return rt === undefined || rt === 'EXTENDS';
+}
+
 export function collectAllSuperTypes(
   currentId: string,
   allEdges: Edge[],
@@ -15,6 +20,7 @@ export function collectAllSuperTypes(
 
   for (const edge of allEdges) {
     if (edge.source !== currentId) continue;
+    if (!isInheritanceEdge(edge)) continue;
     const targetNode = nodeMap.get(edge.target);
     if (!targetNode) continue;
 
@@ -53,7 +59,7 @@ export function buildSuperTypeLevels(
     superTypesByLevel.get(level)!.push(nodeId);
 
     for (const edge of allEdges) {
-      if (edge.source === nodeId && superTypeChain.has(edge.target)) {
+      if (edge.source === nodeId && superTypeChain.has(edge.target) && isInheritanceEdge(edge)) {
         visit(edge.target, level + 1, visited);
       }
     }

--- a/src/features/ili-explorer/services/layout/overviewStrategy.ts
+++ b/src/features/ili-explorer/services/layout/overviewStrategy.ts
@@ -33,7 +33,7 @@ function collectRootClasses(allNodes: IliNode[], allRelations: IliRelation[]): I
     extendsToInternal.add(rel.sourceId);
   }
   return allNodes.filter(n =>
-    n.type === 'classNode'
+    (n.type === 'classNode' || n.type === 'structureNode')
     && !(n.data as { isExternal?: boolean } | undefined)?.isExternal
     && !extendsToInternal.has(n.id),
   );
@@ -121,13 +121,13 @@ export function layoutModelOverview(
     topicIndex++;
   }
 
-  const dependsEdges: Edge[] = [];
+  const edges: Edge[] = [];
   for (const rel of allRelations) {
     if (rel.type !== 'DEPENDS') continue;
     const sourceId = topicLabelIdByName.get(rel.sourceId);
     const targetId = topicLabelIdByName.get(rel.targetId);
     if (!sourceId || !targetId) continue;
-    dependsEdges.push({
+    edges.push({
       id: `depends-${rel.sourceId}-${rel.targetId}`,
       source: sourceId,
       target: targetId,
@@ -141,5 +141,5 @@ export function layoutModelOverview(
     });
   }
 
-  return { nodes: placedNodes, edges: dependsEdges };
+  return { nodes: placedNodes, edges };
 }

--- a/src/features/ili-explorer/services/parser/__fixtures__/Conformance_Synthetic_V1.ili
+++ b/src/features/ili-explorer/services/parser/__fixtures__/Conformance_Synthetic_V1.ili
@@ -47,12 +47,16 @@
 !!       SURFACE, MULTISURFACE, AREA (with body), MULTIAREA
 !!     - REFERENCE TO, REFERENCE TO ANYCLASS RESTRICTION
 !!     - BAG / LIST OF with cardinality
+!!     - BAG OF ANYSTRUCTURE, LIST OF Struct RESTRICTION (Refhb 3.6 P1.3)
+!!     - single Strukturattribut (Refhb 3.6 P1.2) — CONTAINS-Relation
 !!     - multi-property (ABSTRACT, EXTENDED, TRANSIENT, FINAL)
 !!     - MANDATORY without explicit type
 !!     - default-value list (:= 1, 2, 3)
 !!     - 5 inline enumerations across two classes
 !!   ASSOCIATIONS
 !!     - 2-role, self-association, cross-topic
+!!     - Composition `-<#>`, Aggregation `-<>` (Refhb 3.7 P1.5)
+!!     - OR-Alternative im targetClass (Refhb 3.7 P1.6)
 !!
 !! License
 !!   MIT — original work, modvis project. Free to use, modify, redistribute.
@@ -231,6 +235,8 @@ MODEL Conformance_Synthetic_V1 (en)
       d : MANDATORY;
       e : REFERENCE TO ANYCLASS RESTRICTION (ClsBravo1; ClsBravo2);
       F08 : NUMERIC := 1, 2, 3;
+      !! Refhb 3.6 Strukturattribut — single embedded Structure (P1.2 CONTAINS)
+      Embedded : MANDATORY TopicAlpha.StructAlpha1;
       !! inline enums — 3 separate Aufzählungen as AttrTypeDef
       InlineE1 : (k_alpha, k_bravo, k_charlie);
       InlineE2 : (k_x, k_y, k_z);
@@ -238,6 +244,16 @@ MODEL Conformance_Synthetic_V1 (en)
       !! class-level UNIQUE constraint (constraintClause inside body)
       UNIQUE F08;
     END ClsBravo8;
+
+    !!@ comment="P1.3 collection edge-cases: ANYSTRUCTURE, RESTRICTION"
+    CLASS ClsBravo9 =
+      F01 : MANDATORY TEXT*40;
+      !! Refhb 3.6: BAG OF ANYSTRUCTURE — heterogene Strukturwerte
+      Payload  : BAG {0..*} OF ANYSTRUCTURE;
+      !! Refhb 3.6: BAG OF Struct RESTRICTION (...) — eingegrenzte Struct-Auswahl
+      Restrict : LIST {1..*} OF TopicAlpha.StructAlpha1
+                   RESTRICTION (TopicAlpha.StructAlpha1; TopicAlpha.StructAlpha2);
+    END ClsBravo9;
 
     !! standard 2-role association
     ASSOCIATION AssocBravo01 =
@@ -250,6 +266,24 @@ MODEL Conformance_Synthetic_V1 (en)
       Side1 -- {0..*} ClsBravo1;
       Side2 -- {0..*} ClsBravo1;
     END AssocBravo02;
+
+    !! Refhb 3.7 P1.5 — Composition `-<#>` (filled diamond, strong ownership)
+    ASSOCIATION AssocBravo03 =
+      Owner -<#> {1} ClsBravo1;
+      Part  -- {0..*} ClsBravo3;
+    END AssocBravo03;
+
+    !! Refhb 3.7 P1.5 — Aggregation `-<>` (open diamond, weak ownership)
+    ASSOCIATION AssocBravo04 =
+      Whole -<> {1} ClsBravo1;
+      Item  -- {0..*} ClsBravo2;
+    END AssocBravo04;
+
+    !! Refhb 3.7 P1.6 — Rollen-Target mit OR-Alternative (polymorph)
+    ASSOCIATION AssocBravo05 =
+      RefA -- {1} ClsBravo1;
+      RefB -- {0..*} ClsBravo2 OR ClsBravo3;
+    END AssocBravo05;
 
     !! topic-level CONSTRAINTS OF block targeting a class
     CONSTRAINTS OF ClsBravo1 =

--- a/src/features/ili-explorer/services/parser/__tests__/conformance.test.ts
+++ b/src/features/ili-explorer/services/parser/__tests__/conformance.test.ts
@@ -97,4 +97,92 @@ describe('IliParser conformance — synthetic fixture', () => {
     expect(relations.filter(r => r.type === 'EXTENDS').length).toBeGreaterThan(0);
     expect(relations.filter(r => r.type === 'REFERENCES').length).toBeGreaterThan(0);
   });
+
+  it('P1.2 — emits CONTAINS relations for structure-valued attributes', () => {
+    const { nodes, relations } = new IliParser().parseContent(readFileSync(SYNTHETIC_FIXTURE, 'utf8'));
+    const containsRels = relations.filter(r => r.type === 'CONTAINS');
+    expect(containsRels.length).toBeGreaterThan(0);
+
+    const single = containsRels.find(r =>
+      r.sourceId === 'TopicBravo.ClsBravo8' && r.targetId === 'TopicAlpha.StructAlpha1',
+    );
+    expect(single).toBeDefined();
+
+    const bag = containsRels.find(r =>
+      r.sourceId === 'TopicBravo.ClsBravo1' && r.targetId === 'TopicAlpha.StructAlpha2',
+    );
+    expect(bag).toBeDefined();
+
+    const bravo8 = nodes.find(n => n.id === 'TopicBravo.ClsBravo8') as any;
+    const embedded = bravo8?.attributes?.find((a: any) => a.name === 'Embedded');
+    expect(embedded?.isStructValue).toBe(true);
+    expect(embedded?.structKind).toBe('single');
+  });
+
+  it('P1.3 — parses BAG OF ANYSTRUCTURE and BAG/LIST OF Struct RESTRICTION', () => {
+    const content = readFileSync(SYNTHETIC_FIXTURE, 'utf8');
+    const { nodes, errors } = new IliParser().parseContent(content);
+    expect(errors).toEqual([]);
+    const bravo9 = nodes.find(n => n.id === 'TopicBravo.ClsBravo9') as any;
+    expect(bravo9).toBeDefined();
+    const payload = bravo9.attributes.find((a: any) => a.name === 'Payload');
+    expect(payload?.type).toContain('ANYSTRUCTURE');
+    const restrict = bravo9.attributes.find((a: any) => a.name === 'Restrict');
+    expect(restrict?.type).toContain('RESTRICTION');
+  });
+
+  it('P1.5 — persists composition and aggregation kinds on associations', () => {
+    const { nodes } = new IliParser().parseContent(readFileSync(SYNTHETIC_FIXTURE, 'utf8'));
+    const assocs = nodes.filter(n => n.type === 'ASSOCIATION');
+    const comp = assocs.find(n => n.name === 'AssocBravo03') as any;
+    const agg = assocs.find(n => n.name === 'AssocBravo04') as any;
+    expect(comp?.data?.association?.kind).toBe('composition');
+    expect(agg?.data?.association?.kind).toBe('aggregation');
+  });
+
+  it('P1.6 — preserves OR alternatives in role target', () => {
+    const { nodes } = new IliParser().parseContent(readFileSync(SYNTHETIC_FIXTURE, 'utf8'));
+    const assoc = nodes.find(n => n.name === 'AssocBravo05') as any;
+    const alts = assoc?.data?.association?.targetAlternatives;
+    expect(alts).toBeDefined();
+    expect(alts.length).toBeGreaterThanOrEqual(1);
+    expect(alts.some((a: string) => a.endsWith('ClsBravo3'))).toBe(true);
+  });
+
+  it('Refhb 3.5.3 — emits warning when STRUCTURE EXTENDS a CLASS', () => {
+    const ili = `INTERLIS 2.4;
+      MODEL M = TOPIC T =
+        CLASS C = a : TEXT*4; END C;
+        STRUCTURE S EXTENDS C = b : TEXT*4; END S;
+      END T;
+      END M.`;
+    const { warnings = [] } = new IliParser().parseContent(ili);
+    expect(warnings.some(w => /Refhb 3\.5\.3/.test(w.message))).toBe(true);
+  });
+
+  it('Refhb 3.6 — RESTRICTION on REFERENCE TO yields REFERENCES per restricted class', () => {
+    const { relations } = new IliParser().parseContent(readFileSync(SYNTHETIC_FIXTURE, 'utf8'));
+    const fromBravo8 = relations.filter(r =>
+      r.type === 'REFERENCES' && r.sourceId === 'TopicBravo.ClsBravo8' && r.role === 'e',
+    );
+    const targets = fromBravo8.map(r => r.targetId).sort();
+    expect(targets).toEqual(['TopicBravo.ClsBravo1', 'TopicBravo.ClsBravo2']);
+    expect(targets).not.toContain('TopicBravo.ANYCLASS');
+  });
+
+  it('Refhb 3.5.3 — STRUCTURE properties: ABSTRACT/FINAL/EXTENDED are distinct', () => {
+    const ili = `INTERLIS 2.4;
+      MODEL M = TOPIC T =
+        STRUCTURE Sa (ABSTRACT) = x : TEXT*4; END Sa;
+        STRUCTURE Sf (FINAL) = x : TEXT*4; END Sf;
+      END T;
+      END M.`;
+    const { nodes } = new IliParser().parseContent(ili);
+    const sa = nodes.find(n => n.name === 'Sa') as any;
+    const sf = nodes.find(n => n.name === 'Sf') as any;
+    expect(sa?.data?.isAbstract).toBe(true);
+    expect(sa?.data?.isFinal).toBe(false);
+    expect(sf?.data?.isAbstract).toBe(false);
+    expect(sf?.data?.isFinal).toBe(true);
+  });
 });

--- a/src/features/ili-explorer/services/parser/astBuilder.ts
+++ b/src/features/ili-explorer/services/parser/astBuilder.ts
@@ -1,6 +1,7 @@
 import type { CstNode, IToken } from 'chevrotain';
 import type {
   IliBaseNode, IliRelation, IliAttribute, IliEnumValue, IliAssociation,
+  IliAssociationKind,
 } from '../types/IliBaseTypes';
 import type { IliClassNode, IliStructureNode } from '../types/IliModelTypes';
 import type { IliImportRef, IliParseError } from './types';
@@ -96,9 +97,11 @@ class IliCstToAstVisitor extends BaseVisitor {
     this.commentBefore = commentBefore;
     this.visit(cst);
     this.decorateDomainAttributes();
+    this.decorateStructureAttributes();
     this.decorateAssociations();
     this.decorateReferences();
     this.decorateInheritedAttributes();
+    this.validateStructureInheritance();
     this.decorateExternalNodes();
     return {
       nodes: this.state.nodes,
@@ -142,6 +145,79 @@ class IliCstToAstVisitor extends BaseVisitor {
           isActive: false,
         },
       });
+    }
+  }
+
+  private validateStructureInheritance(): void {
+    const typeById = new Map<string, string>();
+    for (const node of this.state.nodes) typeById.set(node.id, node.type);
+    for (const rel of this.state.relations) {
+      if (rel.type !== 'EXTENDS') continue;
+      const sourceType = typeById.get(rel.sourceId);
+      const targetType = typeById.get(rel.targetId);
+      if (sourceType === 'STRUCTURE' && targetType === 'CLASS') {
+        this.emitWarning(
+          `STRUCTURE '${rel.sourceId}' erweitert die CLASS '${rel.targetId}' — Refhb 3.5.3 verbietet das.`,
+        );
+      }
+    }
+  }
+
+  private decorateStructureAttributes(): void {
+    const structIds = new Set<string>();
+    for (const node of this.state.nodes) {
+      if (node.type === 'STRUCTURE') structIds.add(node.id);
+    }
+    if (structIds.size === 0) return;
+
+    const seenContains = new Set<string>();
+    const tryEmit = (sourceId: string, targetId: string, attrName: string) => {
+      const key = `${sourceId}|${targetId}|${attrName}`;
+      if (seenContains.has(key)) return;
+      seenContains.add(key);
+      this.state.relations.push({
+        id: `${sourceId}-${attrName}-${targetId}-contains`,
+        sourceId,
+        targetId,
+        type: 'CONTAINS',
+        role: attrName,
+      });
+    };
+
+    for (const node of this.state.nodes) {
+      if (node.type !== 'CLASS' && node.type !== 'STRUCTURE') continue;
+      const owner = node as IliClassNode;
+      if (!owner.attributes) continue;
+      for (const attr of owner.attributes) {
+        if (!attr.isEnum && !attr.isInlineEnum && !attr.isDomainEnum && !attr.isReference) {
+          const t = attr.type ?? '';
+          const primitive = /^(TEXT|MTEXT|NUMERIC|BOOLEAN|DATE|DATETIME|COORD|MULTICOORD|POLYLINE|MULTIPOLYLINE|SURFACE|MULTISURFACE|AREA|MULTIAREA|GEOMETRY|FORMAT|ENUMERATION|BAG|LIST|REFERENCE)\b/.test(t);
+          if (!primitive && t.length > 0) {
+            const candidate = qualifyRef(t, owner.topicId ?? '');
+            if (structIds.has(candidate)) {
+              attr.isStructValue = true;
+              attr.structRef = candidate;
+              attr.structKind = 'single';
+              tryEmit(owner.id, candidate, attr.name);
+            }
+          }
+        }
+        if (attr.isReference) {
+          const m = attr.type?.match(/^(BAG|LIST)(?:\s+\{[^}]*\})?\s+OF\s+(\S+)$/);
+          if (m) {
+            const target = qualifyRef(m[2], owner.topicId ?? '');
+            if (structIds.has(target)) {
+              attr.isStructValue = true;
+              attr.structRef = target;
+              attr.structKind = m[1] === 'BAG' ? 'bag' : 'list';
+              tryEmit(owner.id, target, attr.name);
+            }
+          }
+        }
+      }
+      if (owner.data && Array.isArray(owner.data.attributes)) {
+        owner.data.attributes = owner.attributes;
+      }
     }
   }
 
@@ -419,7 +495,10 @@ class IliCstToAstVisitor extends BaseVisitor {
   structureDef(ctx: any) {
     const structName = imageOf(ctx.structName?.[0]);
     const structId = qualifyLocal(structName, this.state.topicName);
-    const isAbstract = !!ctx.classModifier;
+    const mod = ctx.classModifier?.[0]?.children ?? {};
+    const isAbstract = !!mod.Abstract;
+    const isFinal = !!mod.Final;
+    const isExtended = !!mod.Extended;
     const comment = this.commentFor(ctx.Structure?.[0]);
 
     let superTypeQualified: string | undefined;
@@ -448,6 +527,8 @@ class IliCstToAstVisitor extends BaseVisitor {
       data: {
         label: structName,
         isAbstract,
+        isFinal,
+        isExtended,
         attributes,
         topic: this.state.topicName,
         comment,
@@ -472,25 +553,49 @@ class IliCstToAstVisitor extends BaseVisitor {
     const target = ctx.AnyClass
       ? 'ANYCLASS'
       : (this.visit(ctx.qualifiedName[0]) as string);
-    return {
-      type: `REFERENCE TO ${target}`,
+    const restriction = ctx.restrictionClause
+      ? this.visit(ctx.restrictionClause[0]) as string[]
+      : undefined;
+    const restrPart = restriction && restriction.length > 0
+      ? ` RESTRICTION (${restriction.join('; ')})`
+      : '';
+    const result: Partial<IliAttribute> = {
+      type: `REFERENCE TO ${target}${restrPart}`,
       isReference: true,
     };
+    if (restriction && restriction.length > 0) {
+      result.restriction = restriction;
+    }
+    return result;
   }
 
   collectionType(ctx: any): Partial<IliAttribute> {
     const isBag = !!ctx.Bag;
     const card = ctx.cardinality ? this.visit(ctx.cardinality[0]) as string : undefined;
-    const target = this.visit(ctx.qualifiedName[0]) as string;
+    const target = ctx.AnyStructure
+      ? 'ANYSTRUCTURE'
+      : (this.visit(ctx.qualifiedName[0]) as string);
+    const restriction = ctx.restrictionClause
+      ? this.visit(ctx.restrictionClause[0]) as string[]
+      : undefined;
     const kind = isBag ? 'BAG' : 'LIST';
     const cardPart = card ? ` {${card}}` : '';
-    return { type: `${kind}${cardPart} OF ${target}`, isReference: true };
+    const restrPart = restriction && restriction.length > 0
+      ? ` RESTRICTION (${restriction.join('; ')})`
+      : '';
+    return { type: `${kind}${cardPart} OF ${target}${restrPart}`, isReference: true };
+  }
+
+  restrictionClause(ctx: any): string[] {
+    const qns = ctx.qualifiedName as CstNode[] | undefined;
+    if (!qns) return [];
+    return qns.map(q => this.visit(q) as string);
   }
 
   associationDef(ctx: any) {
     const assocName = imageOf(ctx.assocName?.[0]);
     const roles = (ctx.roleDef as CstNode[] | undefined)?.map(
-      r => this.visit(r) as { roleName: string; targetClass: string; cardinality: string },
+      r => this.visit(r) as ReturnType<IliCstToAstVisitor['roleDef']>,
     ) ?? [];
     if (roles.length !== 2) {
       this.emitWarning(
@@ -502,6 +607,12 @@ class IliCstToAstVisitor extends BaseVisitor {
     const [source, target] = roles;
     const assocId = qualifyLocal(`assoc_${assocName}`, this.state.topicName);
     const comment = this.commentFor(ctx.Association?.[0]) ?? this.commentFor(ctx.assocName?.[0]);
+    const kind = source.kind !== 'plain' ? source.kind
+      : target.kind !== 'plain' ? target.kind
+      : 'plain';
+    const targetAlternatives = target.targetAlternatives?.map(
+      raw => qualifyRef(raw, this.state.topicName),
+    );
     const assoc: IliAssociation = {
       id: assocId,
       name: assocName,
@@ -512,15 +623,35 @@ class IliCstToAstVisitor extends BaseVisitor {
       sourceCardinality: source.cardinality,
       targetCardinality: target.cardinality,
       comment,
+      kind,
     };
+    if (targetAlternatives && targetAlternatives.length > 0) {
+      assoc.targetAlternatives = targetAlternatives;
+    }
     this.state.parsedAssociations.push(assoc);
   }
 
-  roleDef(ctx: any): { roleName: string; targetClass: string; cardinality: string } {
+  roleDef(ctx: any): {
+    roleName: string;
+    targetClass: string;
+    cardinality: string;
+    kind: IliAssociationKind;
+    targetAlternatives?: string[];
+  } {
+    let kind: IliAssociationKind = 'plain';
+    if (ctx.CompositionArrow) kind = 'composition';
+    else if (ctx.AggregationArrow) kind = 'aggregation';
+    const targetAlternatives = (ctx.targetClassAlt as CstNode[] | undefined)?.map(
+      a => this.visit(a) as string,
+    );
     return {
       roleName: imageOf(ctx.roleName?.[0]),
       targetClass: ctx.targetClass?.[0] ? this.visit(ctx.targetClass[0]) as string : '',
       cardinality: ctx.cardinality?.[0] ? this.visit(ctx.cardinality[0]) as string : '',
+      kind,
+      ...(targetAlternatives && targetAlternatives.length > 0
+        ? { targetAlternatives }
+        : {}),
     };
   }
 
@@ -675,7 +806,10 @@ class IliCstToAstVisitor extends BaseVisitor {
   classDef(ctx: any) {
     const className = imageOf(ctx.className?.[0]);
     const classId = qualifyLocal(className, this.state.topicName);
-    const isAbstract = !!ctx.classModifier;
+    const mod = ctx.classModifier?.[0]?.children ?? {};
+    const isAbstract = !!mod.Abstract;
+    const isFinal = !!mod.Final;
+    const isExtended = !!mod.Extended;
     const comment = this.commentFor(ctx.Class?.[0]);
 
     let superTypeQualified: string | undefined;
@@ -694,13 +828,25 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
 
     for (const attr of attributes) {
-      if (attr.isReference && attr.type.startsWith('REFERENCE TO ')) {
-        const target = attr.type.slice('REFERENCE TO '.length).trim();
+      if (!attr.isReference || !attr.type.startsWith('REFERENCE TO ')) continue;
+      const restriction = attr.restriction;
+      const refBase = attr.type.slice('REFERENCE TO '.length);
+      const base = refBase.split(' RESTRICTION')[0].trim();
+      if (restriction && restriction.length > 0) {
+        for (const r of restriction) {
+          this.state.pendingReferences.push({
+            sourceClass: classId,
+            targetQualified: qualifyRef(r, this.state.topicName),
+            attrName: attr.name,
+            isExternal: r.includes('.'),
+          });
+        }
+      } else {
         this.state.pendingReferences.push({
           sourceClass: classId,
-          targetQualified: qualifyRef(target, this.state.topicName),
+          targetQualified: qualifyRef(base, this.state.topicName),
           attrName: attr.name,
-          isExternal: target.includes('.'),
+          isExternal: base.includes('.'),
         });
       }
     }
@@ -710,6 +856,7 @@ class IliCstToAstVisitor extends BaseVisitor {
       type: 'CLASS',
       name: className,
       isAbstract,
+      isFinal,
       position: { x: 0, y: 0 },
       attributes,
       associations: [],
@@ -719,6 +866,8 @@ class IliCstToAstVisitor extends BaseVisitor {
       data: {
         label: className,
         isAbstract,
+        isFinal,
+        isExtended,
         attributes,
         associations: [],
         inheritedAttributes: [],

--- a/src/features/ili-explorer/services/parser/grammar/attribute.ts
+++ b/src/features/ili-explorer/services/parser/grammar/attribute.ts
@@ -5,7 +5,7 @@ import {
   LParen, RParen, LBrace, RBrace, LBracket, RBracket,
   Mandatory, Extended, Abstract, Final, Transient,
   Text, MText, Numeric, Boolean, Date, DateTime,
-  Reference, To, External, AnyClass,
+  Reference, To, External, AnyClass, AnyStructure,
   Bag, List, Of,
   Coord, MultiCoord, Polyline, MultiPolyline,
   Surface, MultiSurface, Area, MultiArea,
@@ -108,7 +108,11 @@ export function registerAttributeRules(p: IliCstParserBuilder): void {
     ]);
     p.OPTION(() => p.SUBRULE(p.cardinality));
     p.CONSUME(Of);
-    p.SUBRULE(p.qualifiedName);
+    p.OR2([
+      { ALT: () => p.CONSUME(AnyStructure) },
+      { ALT: () => p.SUBRULE(p.qualifiedName) },
+    ]);
+    p.OPTION2(() => p.SUBRULE(p.restrictionClause));
   });
 
   p.textType = p.RULE('textType', () => {

--- a/src/features/ili-explorer/services/parser/grammar/class.ts
+++ b/src/features/ili-explorer/services/parser/grammar/class.ts
@@ -58,10 +58,12 @@ export function registerClassRules(p: IliCstParserBuilder): void {
     p.OPTION(() => p.SUBRULE(p.classModifier));
     p.OPTION2(() => p.SUBRULE(p.extendsClause));
     p.CONSUME(Equals);
+    p.OPTION3(() => p.CONSUME(Attribute));
     p.MANY(() => {
       p.OR([
         { ALT: () => p.SUBRULE(p.attributeDef) },
         { ALT: () => p.SUBRULE(p.constraintClause) },
+        { ALT: () => p.CONSUME2(Attribute) },
       ]);
     });
     p.CONSUME(End);

--- a/src/features/ili-explorer/services/types/IliBaseTypes.ts
+++ b/src/features/ili-explorer/services/types/IliBaseTypes.ts
@@ -56,7 +56,13 @@ export interface IliAttribute {
   comment?: string;
   attributeGroup?: string;
   domainEnumRef?: string;
+  isStructValue?: boolean;
+  structRef?: string;
+  structKind?: 'single' | 'bag' | 'list';
+  restriction?: string[];
 }
+
+export type IliAssociationKind = 'plain' | 'aggregation' | 'composition';
 
 export interface IliAssociation {
   id: string;
@@ -68,6 +74,8 @@ export interface IliAssociation {
   sourceCardinality?: string;
   targetCardinality?: string;
   comment?: string;
+  kind?: IliAssociationKind;
+  targetAlternatives?: string[];
 }
 
 export interface IliBaseNodeData {
@@ -96,11 +104,12 @@ export interface IliBaseNode {
   data: IliBaseNodeData;
 }
 
-export type IliRelationType = 
-  | 'EXTENDS' 
-  | 'DEPENDS' 
+export type IliRelationType =
+  | 'EXTENDS'
+  | 'DEPENDS'
   | 'ASSOCIATES'
-  | 'REFERENCES';
+  | 'REFERENCES'
+  | 'CONTAINS';
 
 export interface IliRelation {
   id: string;


### PR DESCRIPTION
- STRUCTURE now has its own click view ("used-in" + contained structures), composition edges (CONTAINS) for class attributes with struct value (single + BAG/LIST OF), header tooltip, hover highlight, and reacts to Magic Layout / Expand All. Color blue-grey (`#607d8b`), distinct from pink (enums).
- Parser robustness: BAG/LIST OF ANYSTRUCTURE [RESTRICTION (...)] (Refhb 3.6), STRUCTURE properties ABSTRACT/EXTENDED/FINAL now detected token-specifically (previously FINAL/EXTENDED were incorrectly flagged as ABSTRACT), optional ATTRIBUTE keyword in structureDef, warning on `STRUCTURE EXTENDS CLASS` (forbidden per Refhb 3.5.3).
- REFERENCES edges are now rendered in the flow diagram (previously `inheritanceEdgesFromRelations` filtered only EXTENDS, so every `REFERENCE TO` relation was silently invisible). RESTRICTION clause on `REFERENCE TO` is now lifted into the AST: each restricted entry becomes its own REFERENCES edge — no more ANYCLASS phantom on `REFERENCE TO ANYCLASS RESTRICTION (...)`.
- Associations: role strength `--`/`-<>`/`-<#>` (Refhb 3.7) is now persisted and rendered with distinct edge style + header stereotype; OR alternatives in role targets are preserved.
- Click view layout consolidated: right column stacks REFERENCES + enums + contained structures with shared Y spacing (no overlap), left column stacks struct owners + reference sources.
- ModelInfoPanel chip `N Structures`, legend entries CONTAINS + REFERENCES; synthetic fixture extended to cover all new constructs