### PR TITLE
fix(parser): close grammar gaps blocking Standard-Library CoordSys.ili

### DIFF
--- a/src/features/ili-explorer/services/parser/__fixtures__/CoordSys.ili
+++ b/src/features/ili-explorer/services/parser/__fixtures__/CoordSys.ili
@@ -1,0 +1,213 @@
+!! File CoordSys.ili Release 2015-11-24
+
+INTERLIS 2.3;
+
+!! 2015-11-24 Cardinalities adapted (line 122, 123, 124, 132, 133, 134, 142, 143,
+!!                                   148, 149, 163, 164, 168, 169, 206 and 207)
+!!@precursorVersion = 2005-06-16
+
+REFSYSTEM MODEL CoordSys (en) AT "http://www.interlis.ch/models"
+  VERSION "2015-11-24" =
+
+  UNIT
+    Angle_Degree = 180 / PI [INTERLIS.rad];
+    Angle_Minute = 1 / 60 [Angle_Degree];
+    Angle_Second = 1 / 60 [Angle_Minute];
+
+  STRUCTURE Angle_DMS_S =
+    Degrees: -180 .. 180 CIRCULAR [Angle_Degree];
+    CONTINUOUS SUBDIVISION Minutes: 0 .. 59 CIRCULAR [Angle_Minute];
+    CONTINUOUS SUBDIVISION Seconds: 0.000 .. 59.999 CIRCULAR [Angle_Second];
+  END Angle_DMS_S;
+
+  DOMAIN
+    Angle_DMS = FORMAT BASED ON Angle_DMS_S (Degrees ":" Minutes ":" Seconds);
+    Angle_DMS_90 EXTENDS Angle_DMS = "-90:00:00.000" .. "90:00:00.000";
+
+
+  TOPIC CoordsysTopic =
+
+    !! Special space aspects to be referenced
+    !! **************************************
+
+    CLASS Ellipsoid EXTENDS INTERLIS.REFSYSTEM =
+      EllipsoidAlias: TEXT*70;
+      SemiMajorAxis: MANDATORY 6360000.0000 .. 6390000.0000 [INTERLIS.m];
+      InverseFlattening: MANDATORY 0.00000000 .. 350.00000000;
+      !! The inverse flattening 0 characterizes the 2-dim sphere
+      Remarks: TEXT*70;
+    END Ellipsoid;
+
+    CLASS GravityModel EXTENDS INTERLIS.REFSYSTEM =
+      GravityModAlias: TEXT*70;
+      Definition: TEXT*70;
+    END GravityModel;
+
+    CLASS GeoidModel EXTENDS INTERLIS.REFSYSTEM =
+      GeoidModAlias: TEXT*70;
+      Definition: TEXT*70;
+    END GeoidModel;
+
+
+    !! Coordinate systems for geodetic purposes
+    !! ****************************************
+
+    STRUCTURE LengthAXIS EXTENDS INTERLIS.AXIS =
+      ShortName: TEXT*12;
+      Description: TEXT*255;
+    PARAMETER
+      Unit (EXTENDED): NUMERIC [INTERLIS.LENGTH];
+    END LengthAXIS;
+
+    STRUCTURE AngleAXIS EXTENDS INTERLIS.AXIS =
+      ShortName: TEXT*12;
+      Description: TEXT*255;
+    PARAMETER
+      Unit (EXTENDED): NUMERIC [INTERLIS.ANGLE];
+    END AngleAXIS;
+
+    CLASS GeoCartesian1D EXTENDS INTERLIS.COORDSYSTEM =
+      Axis (EXTENDED): LIST {1} OF LengthAXIS;
+    END GeoCartesian1D;
+
+    CLASS GeoHeight EXTENDS GeoCartesian1D =
+      System: MANDATORY (
+        normal,
+        orthometric,
+        ellipsoidal,
+        other);
+      ReferenceHeight: MANDATORY -10000.000 .. +10000.000 [INTERLIS.m];
+      ReferenceHeightDescr: TEXT*70;
+    END GeoHeight;
+
+    ASSOCIATION HeightEllips =
+      GeoHeightRef -- {*} GeoHeight;
+      EllipsoidRef -- {1} Ellipsoid;
+    END HeightEllips;
+
+    ASSOCIATION HeightGravit =
+      GeoHeightRef -- {*} GeoHeight;
+      GravityRef -- {1} GravityModel;
+    END HeightGravit;
+
+    ASSOCIATION HeightGeoid =
+      GeoHeightRef -- {*} GeoHeight;
+      GeoidRef -- {1} GeoidModel;
+    END HeightGeoid;
+
+    CLASS GeoCartesian2D EXTENDS INTERLIS.COORDSYSTEM =
+      Definition: TEXT*70;
+      Axis (EXTENDED): LIST {2} OF LengthAXIS;
+    END GeoCartesian2D;
+
+    CLASS GeoCartesian3D EXTENDS INTERLIS.COORDSYSTEM =
+      Definition: TEXT*70;
+      Axis (EXTENDED): LIST {3} OF LengthAXIS;
+    END GeoCartesian3D;
+
+    CLASS GeoEllipsoidal EXTENDS INTERLIS.COORDSYSTEM =
+      Definition: TEXT*70;
+      Axis (EXTENDED): LIST {2} OF AngleAXIS;
+    END GeoEllipsoidal;
+
+    ASSOCIATION EllCSEllips =
+      GeoEllipsoidalRef -- {*} GeoEllipsoidal;
+      EllipsoidRef -- {1} Ellipsoid;
+    END EllCSEllips;
+
+
+    !! Mappings between coordinate systems
+    !! ***********************************
+
+    ASSOCIATION ToGeoEllipsoidal =
+      From -- {0..*} GeoCartesian3D;
+      To -- {0..*} GeoEllipsoidal;
+      ToHeight -- {0..*} GeoHeight;
+    MANDATORY CONSTRAINT
+      ToHeight -> System == #ellipsoidal;
+    MANDATORY CONSTRAINT
+      To -> EllipsoidRef -> Name == ToHeight -> EllipsoidRef -> Name;
+    END ToGeoEllipsoidal;
+
+    ASSOCIATION ToGeoCartesian3D =
+      From2 -- {0..*} GeoEllipsoidal;
+      FromHeight-- {0..*} GeoHeight;
+      To3 -- {0..*} GeoCartesian3D;
+    MANDATORY CONSTRAINT
+      FromHeight -> System == #ellipsoidal;
+    MANDATORY CONSTRAINT
+      From2 -> EllipsoidRef -> Name == FromHeight -> EllipsoidRef -> Name;
+    END ToGeoCartesian3D;
+
+    ASSOCIATION BidirectGeoCartesian2D =
+      From -- {0..*} GeoCartesian2D;
+      To -- {0..*} GeoCartesian2D;
+    END BidirectGeoCartesian2D;
+
+    ASSOCIATION BidirectGeoCartesian3D =
+      From -- {0..*} GeoCartesian3D;
+      To2 -- {0..*} GeoCartesian3D;
+      Precision: MANDATORY (
+        exact,
+        measure_based);
+      ShiftAxis1: MANDATORY -10000.000 .. 10000.000 [INTERLIS.m];
+      ShiftAxis2: MANDATORY -10000.000 .. 10000.000 [INTERLIS.m];
+      ShiftAxis3: MANDATORY -10000.000 .. 10000.000 [INTERLIS.m];
+      RotationAxis1: Angle_DMS_90;
+      RotationAxis2: Angle_DMS_90;
+      RotationAxis3: Angle_DMS_90;
+      NewScale: 0.000001 .. 1000000.000000;
+    END BidirectGeoCartesian3D;
+
+    ASSOCIATION BidirectGeoEllipsoidal =
+      From4 -- {0..*} GeoEllipsoidal;
+      To4 -- {0..*} GeoEllipsoidal;
+    END BidirectGeoEllipsoidal;
+
+    ASSOCIATION MapProjection (ABSTRACT) =
+      From5 -- {0..*} GeoEllipsoidal;
+      To5 -- {0..*} GeoCartesian2D;
+      FromCo1_FundPt: MANDATORY Angle_DMS_90;
+      FromCo2_FundPt: MANDATORY Angle_DMS_90;
+      ToCoord1_FundPt: MANDATORY -10000000 .. +10000000 [INTERLIS.m];
+      ToCoord2_FundPt: MANDATORY -10000000 .. +10000000 [INTERLIS.m];
+    END MapProjection;
+
+    ASSOCIATION TransverseMercator EXTENDS MapProjection =
+    END TransverseMercator;
+
+    ASSOCIATION SwissProjection EXTENDS MapProjection =
+      IntermFundP1: MANDATORY Angle_DMS_90;
+      IntermFundP2: MANDATORY Angle_DMS_90;
+    END SwissProjection;
+
+    ASSOCIATION Mercator EXTENDS MapProjection =
+    END Mercator;
+
+    ASSOCIATION ObliqueMercator EXTENDS MapProjection =
+    END ObliqueMercator;
+
+    ASSOCIATION Lambert EXTENDS MapProjection =
+    END Lambert;
+
+    ASSOCIATION Polyconic EXTENDS MapProjection =
+    END Polyconic;
+
+    ASSOCIATION Albus EXTENDS MapProjection =
+    END Albus;
+
+    ASSOCIATION Azimutal EXTENDS MapProjection =
+    END Azimutal;
+
+    ASSOCIATION Stereographic EXTENDS MapProjection =
+    END Stereographic;
+
+    ASSOCIATION HeightConversion =
+      FromHeight -- {0..*} GeoHeight;
+      ToHeight -- {0..*} GeoHeight;
+      Definition: TEXT*70;
+    END HeightConversion;
+
+  END CoordsysTopic;
+
+END CoordSys.

--- a/src/features/ili-explorer/services/parser/__fixtures__/README.md
+++ b/src/features/ili-explorer/services/parser/__fixtures__/README.md
@@ -1,0 +1,35 @@
+# Parser-Fixtures
+
+Conformance-Korpus für den modvis-Parser. Die Files hier werden direkt von
+Vitest geladen — kein Netzzugriff im CI, deterministisch.
+
+## Provenienz
+
+| Datei                          | Quelle                                              | Stand        | Lizenz                          |
+| ------------------------------ | --------------------------------------------------- | ------------ | ------------------------------- |
+| Conformance_Synthetic_V1.ili   | Eigenentwicklung (modvis)                           | 2026-05-15   | MIT (siehe Header)              |
+| CoordSys.ili                   | https://models.interlis.ch/refhb24/CoordSys.ili     | 2015-11-24   | Public (eCH-0031, swisstopo)    |
+| Units.ili                      | https://models.interlis.ch/refhb24/Units.ili        | 2014-07-09   | Public (eCH-0031, swisstopo)    |
+
+Die `Release`/`VERSION`-Strings in den Header-Kommentaren der Files
+dokumentieren die jeweilige Upstream-Version.
+
+## Refresh-Policy
+
+Snapshot-basiert, bewusst nicht auto-synced:
+
+1. Falls Upstream eine neue Version veröffentlicht: Datei manuell neu
+   herunterladen, in diesen Ordner schreiben (gleicher Dateiname).
+2. Tests laufen — Diff-Review prüft, ob das neue Upstream-File parser-
+   konform ist. Falls nicht: Grammar-Lücke fixen oder Test anpassen.
+3. Tabelle oben aktualisieren (Stand).
+
+So sehen wir Parser-Regressionen bewusst (beim Refresh), statt sie
+unbemerkt in einen automatisch aktualisierten Test einzufangen.
+
+## Verwendung
+
+Tests unter `../__tests__/conformance.test.ts` laden diese Fixtures.
+Wenn W3 (Standard-Library inline mitliefern) umgesetzt wird, ziehen
+diese Files in ein Production-Asset um — die Snapshot-Disziplin bleibt
+gleich.

--- a/src/features/ili-explorer/services/parser/__fixtures__/Units.ili
+++ b/src/features/ili-explorer/services/parser/__fixtures__/Units.ili
@@ -1,0 +1,90 @@
+INTERLIS 2.4;
+
+TYPE MODEL Units (en) AT "http://www.interlis.ch/models/refhb24"
+  VERSION "2014-07-09" =
+
+  UNIT
+    !! abstract Units
+    Area (ABSTRACT) = (INTERLIS.LENGTH*INTERLIS.LENGTH);
+    Volume (ABSTRACT) = (INTERLIS.LENGTH*INTERLIS.LENGTH*INTERLIS.LENGTH);
+    Velocity (ABSTRACT) = (INTERLIS.LENGTH/INTERLIS.TIME);
+    Acceleration (ABSTRACT) = (Velocity/INTERLIS.TIME);
+    Force (ABSTRACT) = (INTERLIS.MASS*INTERLIS.LENGTH/INTERLIS.TIME/INTERLIS.TIME);
+    Pressure (ABSTRACT) = (Force/Area);
+    Energy (ABSTRACT) = (Force*INTERLIS.LENGTH);
+    Power (ABSTRACT) = (Energy/INTERLIS.TIME);
+    Electric_Potential (ABSTRACT) = (Power/INTERLIS.ELECTRIC_CURRENT);
+    Frequency (ABSTRACT) = (INTERLIS.DIMENSIONLESS/INTERLIS.TIME);
+
+    Millimeter [mm] = 0.001 [INTERLIS.m];
+    Centimeter [cm] = 0.01 [INTERLIS.m];
+    Decimeter [dm] = 0.1 [INTERLIS.m];
+    Kilometer [km] = 1000 [INTERLIS.m];
+
+    Square_Meter [m2] EXTENDS Area   = (INTERLIS.m*INTERLIS.m);
+    Cubic_Meter  [m3] EXTENDS Volume = (INTERLIS.m*INTERLIS.m*INTERLIS.m);
+
+    Minute [min] = 60 [INTERLIS.s];
+    Hour   [h]   = 60 [min];
+    Day    [d]   = 24 [h];
+
+    Kilometer_per_Hour [kmh] EXTENDS Velocity = (km/h);
+    Meter_per_Second [ms] = 3.6 [kmh];
+    Newton [N]  EXTENDS Force = (INTERLIS.kg*INTERLIS.m/INTERLIS.s/INTERLIS.s);
+    Pascal [Pa] EXTENDS Pressure = (N/m2);
+    Joule  [J]  EXTENDS Energy = (N*INTERLIS.m);
+    Watt   [W]  EXTENDS Power = (J/INTERLIS.s);
+    Volt   [V]  EXTENDS Electric_Potential = (W/INTERLIS.A);
+
+    Inch [in] = 2.54 [cm];
+    Foot [ft] = 0.3048 [INTERLIS.m];
+    Mile [mi] = 1.609344 [km];
+
+    Are [a] = 100 [m2];
+    Hectare [ha] = 100 [a];
+    Square_Kilometer [km2] = 100 [ha];
+    Acre [acre] = 4046.873 [m2];
+
+    Liter [L] = 1 / 1000 [m3];
+    US_Gallon [USgal] = 3.785412 [L];
+
+    Angle_Degree = 180 / PI [INTERLIS.rad];
+    Angle_Minute = 1 / 60 [Angle_Degree];
+    Angle_Second = 1 / 60 [Angle_Minute];
+
+    Gon = 200 / PI [INTERLIS.rad];
+
+    Gram [g] = 1 / 1000 [INTERLIS.kg];
+    Ton [t] = 1000 [INTERLIS.kg];
+    Pound [lb] = 0.4535924 [INTERLIS.kg];
+
+    Calorie [cal] = 4.1868 [J];
+    Kilowatt_Hour [kWh] = 0.36E7 [J];
+
+    Horsepower = 746 [W];
+
+    Techn_Atmosphere [at] = 98066.5 [Pa];
+    Atmosphere [atm] = 101325 [Pa];
+    Bar [bar] = 100000 [Pa];
+    Millimeter_Mercury [mmHg] = 133.3224 [Pa];
+    Torr = 133.3224 [Pa];
+
+    Decibel [dB] = FUNCTION // 10**(dB/20) * 0.00002 // [Pa];
+
+    Degree_Celsius [oC] = FUNCTION // oC+273.15 // [INTERLIS.K];
+    Degree_Fahrenheit [oF] = FUNCTION // (oF+459.67)/1.8 // [INTERLIS.K];
+
+    CountedObjects EXTENDS INTERLIS.DIMENSIONLESS;
+
+    Hertz [Hz] EXTENDS Frequency = (CountedObjects/INTERLIS.s);
+    KiloHertz [KHz] = 1000 [Hz];
+    MegaHertz [MHz] = 1000 [KHz];
+
+    Percent = 0.01 [CountedObjects];
+    Permille = 0.001 [CountedObjects];
+
+    USDollar    [USD] EXTENDS INTERLIS.MONEY;
+    Euro        [EUR] EXTENDS INTERLIS.MONEY;
+    SwissFrancs [CHF] EXTENDS INTERLIS.MONEY;
+
+END Units.

--- a/src/features/ili-explorer/services/parser/__tests__/conformance.test.ts
+++ b/src/features/ili-explorer/services/parser/__tests__/conformance.test.ts
@@ -170,6 +170,21 @@ describe('IliParser conformance — synthetic fixture', () => {
     expect(targets).not.toContain('TopicBravo.ANYCLASS');
   });
 
+  it('Refhb 3.8.4 + 3.5.3 — Standard-Library CoordSys.ili parses without errors', () => {
+    const path = resolve(__dirname, '../__fixtures__/CoordSys.ili');
+    const { errors, warnings = [] } = new IliParser().parseContent(readFileSync(path, 'utf8'));
+    expect(errors).toEqual([]);
+    const onlyAssocLimitations = warnings.every(w => /ASSOCIATION.*Rollen/.test(w.message));
+    expect(onlyAssocLimitations).toBe(true);
+  });
+
+  it('Standard-Library Units.ili parses without errors or warnings', () => {
+    const path = resolve(__dirname, '../__fixtures__/Units.ili');
+    const { errors, warnings = [] } = new IliParser().parseContent(readFileSync(path, 'utf8'));
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
   it('Refhb 3.5.3 — STRUCTURE properties: ABSTRACT/FINAL/EXTENDED are distinct', () => {
     const ili = `INTERLIS 2.4;
       MODEL M = TOPIC T =

--- a/src/features/ili-explorer/services/parser/astBuilder.ts
+++ b/src/features/ili-explorer/services/parser/astBuilder.ts
@@ -6,32 +6,22 @@ import type {
 import type { IliClassNode, IliStructureNode } from '../types/IliModelTypes';
 import type { IliImportRef, IliParseError } from './types';
 import { cstParserInstance } from './cstParser';
+import {
+  VisitState,
+  lastSegment,
+  qualifyLocal,
+  qualifyRef,
+  emitWarning,
+  decorateExternalNodes,
+  validateStructureInheritance,
+  decorateStructureAttributes,
+  decorateReferences,
+  decorateInheritedAttributes,
+  decorateAssociations,
+  decorateDomainAttributes,
+} from './decorators';
 
 const BaseVisitor = cstParserInstance.getBaseCstVisitorConstructorWithDefaults();
-
-interface VisitState {
-  topicName: string;
-  nodes: IliBaseNode[];
-  relations: IliRelation[];
-  imports: IliImportRef[];
-  interlisVersion: string | undefined;
-  domainEnumsByName: Map<string, IliEnumValue[]>;
-  parsedAssociations: IliAssociation[];
-  pendingReferences: { sourceClass: string; targetQualified: string; attrName: string; isExternal: boolean }[];
-  warnings: IliParseError[];
-}
-
-function lastSegment(qualified: string): string {
-  return qualified.includes('.') ? qualified.split('.').pop()! : qualified;
-}
-
-function qualifyLocal(localName: string, topicName: string): string {
-  return topicName ? `${topicName}.${localName}` : localName;
-}
-
-function qualifyRef(rawRef: string, currentTopic: string): string {
-  return rawRef.includes('.') ? rawRef : qualifyLocal(rawRef, currentTopic);
-}
 
 function imageOf(token: IToken | undefined): string {
   return token ? token.image : '';
@@ -96,13 +86,13 @@ class IliCstToAstVisitor extends BaseVisitor {
     };
     this.commentBefore = commentBefore;
     this.visit(cst);
-    this.decorateDomainAttributes();
-    this.decorateStructureAttributes();
-    this.decorateAssociations();
-    this.decorateReferences();
-    this.decorateInheritedAttributes();
-    this.validateStructureInheritance();
-    this.decorateExternalNodes();
+    decorateDomainAttributes(this.state);
+    decorateStructureAttributes(this.state);
+    decorateAssociations(this.state);
+    decorateReferences(this.state);
+    decorateInheritedAttributes(this.state);
+    validateStructureInheritance(this.state);
+    decorateExternalNodes(this.state);
     return {
       nodes: this.state.nodes,
       relations: this.state.relations,
@@ -112,127 +102,6 @@ class IliCstToAstVisitor extends BaseVisitor {
     };
   }
 
-  private emitWarning(message: string, token?: IToken): void {
-    this.state.warnings.push({
-      message,
-      severity: 'warning',
-      offset: token?.startOffset,
-      line: token?.startLine,
-      column: token?.startColumn,
-    });
-  }
-
-  private decorateExternalNodes(): void {
-    const knownIds = new Set(this.state.nodes.map(n => n.id));
-    const seen = new Set<string>();
-    for (const rel of this.state.relations) {
-      if (knownIds.has(rel.targetId) || seen.has(rel.targetId)) continue;
-      seen.add(rel.targetId);
-      const localName = lastSegment(rel.targetId);
-      const externalSource = rel.targetId.includes('.')
-        ? rel.targetId.slice(0, rel.targetId.lastIndexOf('.'))
-        : undefined;
-      this.state.nodes.push({
-        id: rel.targetId,
-        type: 'CLASS',
-        name: localName,
-        position: { x: 0, y: 0 },
-        data: {
-          label: localName,
-          isExternal: true,
-          externalSource,
-          isHighlighted: false,
-          isActive: false,
-        },
-      });
-    }
-  }
-
-  private validateStructureInheritance(): void {
-    const typeById = new Map<string, string>();
-    for (const node of this.state.nodes) typeById.set(node.id, node.type);
-    for (const rel of this.state.relations) {
-      if (rel.type !== 'EXTENDS') continue;
-      const sourceType = typeById.get(rel.sourceId);
-      const targetType = typeById.get(rel.targetId);
-      if (sourceType === 'STRUCTURE' && targetType === 'CLASS') {
-        this.emitWarning(
-          `STRUCTURE '${rel.sourceId}' erweitert die CLASS '${rel.targetId}' — Refhb 3.5.3 verbietet das.`,
-        );
-      }
-    }
-  }
-
-  private decorateStructureAttributes(): void {
-    const structIds = new Set<string>();
-    for (const node of this.state.nodes) {
-      if (node.type === 'STRUCTURE') structIds.add(node.id);
-    }
-    if (structIds.size === 0) return;
-
-    const seenContains = new Set<string>();
-    const tryEmit = (sourceId: string, targetId: string, attrName: string) => {
-      const key = `${sourceId}|${targetId}|${attrName}`;
-      if (seenContains.has(key)) return;
-      seenContains.add(key);
-      this.state.relations.push({
-        id: `${sourceId}-${attrName}-${targetId}-contains`,
-        sourceId,
-        targetId,
-        type: 'CONTAINS',
-        role: attrName,
-      });
-    };
-
-    for (const node of this.state.nodes) {
-      if (node.type !== 'CLASS' && node.type !== 'STRUCTURE') continue;
-      const owner = node as IliClassNode;
-      if (!owner.attributes) continue;
-      for (const attr of owner.attributes) {
-        if (!attr.isEnum && !attr.isInlineEnum && !attr.isDomainEnum && !attr.isReference) {
-          const t = attr.type ?? '';
-          const primitive = /^(TEXT|MTEXT|NUMERIC|BOOLEAN|DATE|DATETIME|COORD|MULTICOORD|POLYLINE|MULTIPOLYLINE|SURFACE|MULTISURFACE|AREA|MULTIAREA|GEOMETRY|FORMAT|ENUMERATION|BAG|LIST|REFERENCE)\b/.test(t);
-          if (!primitive && t.length > 0) {
-            const candidate = qualifyRef(t, owner.topicId ?? '');
-            if (structIds.has(candidate)) {
-              attr.isStructValue = true;
-              attr.structRef = candidate;
-              attr.structKind = 'single';
-              tryEmit(owner.id, candidate, attr.name);
-            }
-          }
-        }
-        if (attr.isReference) {
-          const m = attr.type?.match(/^(BAG|LIST)(?:\s+\{[^}]*\})?\s+OF\s+(\S+)$/);
-          if (m) {
-            const target = qualifyRef(m[2], owner.topicId ?? '');
-            if (structIds.has(target)) {
-              attr.isStructValue = true;
-              attr.structRef = target;
-              attr.structKind = m[1] === 'BAG' ? 'bag' : 'list';
-              tryEmit(owner.id, target, attr.name);
-            }
-          }
-        }
-      }
-      if (owner.data && Array.isArray(owner.data.attributes)) {
-        owner.data.attributes = owner.attributes;
-      }
-    }
-  }
-
-  private decorateReferences(): void {
-    for (const ref of this.state.pendingReferences) {
-      this.state.relations.push({
-        id: `${ref.sourceClass}-${ref.attrName}-${ref.targetQualified}-ref`,
-        sourceId: ref.sourceClass,
-        targetId: ref.targetQualified,
-        type: 'REFERENCES',
-        role: ref.attrName,
-      });
-    }
-  }
-
   private commentFor(token: IToken | undefined): string | undefined {
     if (!token) return undefined;
     const cs = this.commentBefore.get(token.startOffset);
@@ -240,94 +109,6 @@ class IliCstToAstVisitor extends BaseVisitor {
     const texts = cs.map(extractCommentText).filter((t): t is string => !!t);
     if (texts.length === 0) return undefined;
     return texts.join('\n');
-  }
-
-  private decorateInheritedAttributes(): void {
-    const classById = new Map<string, IliClassNode>();
-    for (const node of this.state.nodes) {
-      if (node.type === 'CLASS' || node.type === 'STRUCTURE') {
-        classById.set(node.id, node as IliClassNode);
-      }
-    }
-
-    const superTypeOf = new Map<string, string>();
-    for (const rel of this.state.relations) {
-      if (rel.type === 'EXTENDS') superTypeOf.set(rel.sourceId, rel.targetId);
-    }
-
-    for (const [classId, classNode] of classById) {
-      const inherited: { className: string; attributes: IliAttribute[] }[] = [];
-      const visited = new Set<string>([classId]);
-      let current = superTypeOf.get(classId);
-      while (current && !visited.has(current)) {
-        visited.add(current);
-        const ancestor = classById.get(current);
-        if (!ancestor) break;
-        if (ancestor.attributes && ancestor.attributes.length > 0) {
-          inherited.push({ className: ancestor.name, attributes: ancestor.attributes });
-        }
-        current = superTypeOf.get(current);
-      }
-      classNode.inheritedAttributes = inherited;
-      classNode.data.inheritedAttributes = inherited;
-    }
-  }
-
-  private decorateAssociations(): void {
-    this.state.parsedAssociations.forEach(assoc => {
-      const sourceNode = this.state.nodes.find(
-        n => n.type === 'CLASS' && n.id === assoc.sourceClass,
-      ) as IliClassNode | undefined;
-      const targetNode = this.state.nodes.find(
-        n => n.type === 'CLASS' && n.id === assoc.targetClass,
-      ) as IliClassNode | undefined;
-      // Self-Assoc nur einmal anhängen — sonst rendert die UI zwei Edges
-      // mit identischer Key und React Flow erzeugt Geister-Edges.
-      const isSelf = sourceNode && targetNode && sourceNode.id === targetNode.id;
-      if (sourceNode) {
-        sourceNode.associations = [...(sourceNode.associations ?? []), assoc];
-        sourceNode.data.associations = sourceNode.associations;
-      }
-      if (targetNode && !isSelf) {
-        targetNode.associations = [...(targetNode.associations ?? []), assoc];
-        targetNode.data.associations = targetNode.associations;
-      }
-
-      // Suchbarkeit: synthetischer ASSOCIATION-Node, damit `generateSearchOptions`
-      // den Assoc-Namen findet. Layout zentriert ihn via `layoutAssociationCenter`.
-      const topic = (sourceNode?.topicId as string | undefined) ?? (targetNode?.topicId as string | undefined) ?? '';
-      this.state.nodes.push({
-        id: assoc.id,
-        type: 'ASSOCIATION',
-        name: assoc.name,
-        position: { x: 0, y: 0 },
-        data: {
-          label: assoc.name,
-          association: assoc,
-          topic,
-          comment: assoc.comment,
-          isHighlighted: false,
-          isActive: false,
-        },
-      });
-    });
-  }
-
-  private decorateDomainAttributes(): void {
-    this.state.nodes.forEach(node => {
-      if (node.type !== 'CLASS') return;
-      const classNode = node as IliClassNode;
-      classNode.attributes?.forEach(attr => {
-        if (attr.isInlineEnum || attr.isEnum) return;
-        const baseName = attr.type.includes('.') ? attr.type.split('.').pop()! : attr.type;
-        const domainValues = this.state.domainEnumsByName.get(baseName);
-        if (domainValues) {
-          attr.isDomainEnum = true;
-          attr.domainEnumName = baseName;
-          attr.enumValues = domainValues;
-        }
-      });
-    });
   }
 
   iliFile(ctx: any) {
@@ -598,7 +379,8 @@ class IliCstToAstVisitor extends BaseVisitor {
       r => this.visit(r) as ReturnType<IliCstToAstVisitor['roleDef']>,
     ) ?? [];
     if (roles.length !== 2) {
-      this.emitWarning(
+      emitWarning(
+        this.state,
         `ASSOCIATION '${assocName}' hat ${roles.length} Rollen — modvis unterstützt aktuell nur binäre Assoziationen (Roles=2). Verworfen.`,
         ctx.assocName?.[0],
       );
@@ -894,14 +676,25 @@ class IliCstToAstVisitor extends BaseVisitor {
   extendsClause() {}
 
   qualifiedName(ctx: any): string {
-    const parts = (ctx.identifierLike as CstNode[] | undefined)
-      ?.map(c => this.visit(c) as string) ?? [];
+    const parts: string[] = [];
+    const first = (ctx.identifierLike as CstNode[] | undefined)?.[0];
+    if (first) parts.push(this.visit(first) as string);
+    const tail = (ctx.qualifiedSegment as CstNode[] | undefined) ?? [];
+    for (const seg of tail) parts.push(this.visit(seg) as string);
     return parts.join('.');
   }
 
   identifierLike(ctx: any): string {
     if (ctx.Identifier) return ctx.Identifier[0].image;
     if (ctx.Interlis) return ctx.Interlis[0].image;
+    return '';
+  }
+
+  qualifiedSegment(ctx: any): string {
+    if (ctx.Identifier) return ctx.Identifier[0].image;
+    if (ctx.Interlis) return ctx.Interlis[0].image;
+    if (ctx.Refsystem) return ctx.Refsystem[0].image;
+    if (ctx.Coordsystem) return ctx.Coordsystem[0].image;
     return '';
   }
 
@@ -948,7 +741,7 @@ class IliCstToAstVisitor extends BaseVisitor {
     }
     if (ctx.formatType) return { type: this.visit(ctx.formatType[0]) as string };
     if (ctx.qualifiedName) return { type: this.visit(ctx.qualifiedName[0]) as string };
-    this.emitWarning('attributeType: keine Variante matched, Typ leer');
+    emitWarning(this.state, 'attributeType: keine Variante matched, Typ leer');
     return { type: '' };
   }
 

--- a/src/features/ili-explorer/services/parser/cstParser.ts
+++ b/src/features/ili-explorer/services/parser/cstParser.ts
@@ -94,6 +94,10 @@ export class IliCstParser extends CstParser {
   domainProp!: any;
   domainConstraintsClause!: any;
   formatType!: any;
+  formatSpec!: any;
+  formatSpecToken!: any;
+  formatRange!: any;
+  qualifiedSegment!: any;
   allOfClause!: any;
   enumerationDef!: any;
   enumValueList!: any;

--- a/src/features/ili-explorer/services/parser/decorators.ts
+++ b/src/features/ili-explorer/services/parser/decorators.ts
@@ -1,0 +1,240 @@
+import type { IToken } from 'chevrotain';
+import type {
+  IliBaseNode, IliRelation, IliAttribute, IliEnumValue, IliAssociation,
+} from '../types/IliBaseTypes';
+import type { IliClassNode } from '../types/IliModelTypes';
+import type { IliImportRef, IliParseError } from './types';
+
+export interface VisitState {
+  topicName: string;
+  nodes: IliBaseNode[];
+  relations: IliRelation[];
+  imports: IliImportRef[];
+  interlisVersion: string | undefined;
+  domainEnumsByName: Map<string, IliEnumValue[]>;
+  parsedAssociations: IliAssociation[];
+  pendingReferences: { sourceClass: string; targetQualified: string; attrName: string; isExternal: boolean }[];
+  warnings: IliParseError[];
+}
+
+export function lastSegment(qualified: string): string {
+  return qualified.includes('.') ? qualified.split('.').pop()! : qualified;
+}
+
+export function qualifyLocal(localName: string, topicName: string): string {
+  return topicName ? `${topicName}.${localName}` : localName;
+}
+
+export function qualifyRef(rawRef: string, currentTopic: string): string {
+  return rawRef.includes('.') ? rawRef : qualifyLocal(rawRef, currentTopic);
+}
+
+export function emitWarning(state: VisitState, message: string, token?: IToken): void {
+  state.warnings.push({
+    message,
+    severity: 'warning',
+    offset: token?.startOffset,
+    line: token?.startLine,
+    column: token?.startColumn,
+  });
+}
+
+export function decorateExternalNodes(state: VisitState): void {
+  const knownIds = new Set(state.nodes.map(n => n.id));
+  const seen = new Set<string>();
+  for (const rel of state.relations) {
+    if (knownIds.has(rel.targetId) || seen.has(rel.targetId)) continue;
+    seen.add(rel.targetId);
+    const localName = lastSegment(rel.targetId);
+    const externalSource = rel.targetId.includes('.')
+      ? rel.targetId.slice(0, rel.targetId.lastIndexOf('.'))
+      : undefined;
+    state.nodes.push({
+      id: rel.targetId,
+      type: 'CLASS',
+      name: localName,
+      position: { x: 0, y: 0 },
+      data: {
+        label: localName,
+        isExternal: true,
+        externalSource,
+        isHighlighted: false,
+        isActive: false,
+      },
+    });
+  }
+}
+
+export function validateStructureInheritance(state: VisitState): void {
+  const typeById = new Map<string, string>();
+  for (const node of state.nodes) typeById.set(node.id, node.type);
+  for (const rel of state.relations) {
+    if (rel.type !== 'EXTENDS') continue;
+    const sourceType = typeById.get(rel.sourceId);
+    const targetType = typeById.get(rel.targetId);
+    if (sourceType === 'STRUCTURE' && targetType === 'CLASS') {
+      emitWarning(
+        state,
+        `STRUCTURE '${rel.sourceId}' erweitert die CLASS '${rel.targetId}' — Refhb 3.5.3 verbietet das.`,
+      );
+    }
+  }
+}
+
+export function decorateStructureAttributes(state: VisitState): void {
+  const structIds = new Set<string>();
+  for (const node of state.nodes) {
+    if (node.type === 'STRUCTURE') structIds.add(node.id);
+  }
+  if (structIds.size === 0) return;
+
+  const seenContains = new Set<string>();
+  const tryEmit = (sourceId: string, targetId: string, attrName: string) => {
+    const key = `${sourceId}|${targetId}|${attrName}`;
+    if (seenContains.has(key)) return;
+    seenContains.add(key);
+    state.relations.push({
+      id: `${sourceId}-${attrName}-${targetId}-contains`,
+      sourceId,
+      targetId,
+      type: 'CONTAINS',
+      role: attrName,
+    });
+  };
+
+  for (const node of state.nodes) {
+    if (node.type !== 'CLASS' && node.type !== 'STRUCTURE') continue;
+    const owner = node as IliClassNode;
+    if (!owner.attributes) continue;
+    for (const attr of owner.attributes) {
+      if (!attr.isEnum && !attr.isInlineEnum && !attr.isDomainEnum && !attr.isReference) {
+        const t = attr.type ?? '';
+        const primitive = /^(TEXT|MTEXT|NUMERIC|BOOLEAN|DATE|DATETIME|COORD|MULTICOORD|POLYLINE|MULTIPOLYLINE|SURFACE|MULTISURFACE|AREA|MULTIAREA|GEOMETRY|FORMAT|ENUMERATION|BAG|LIST|REFERENCE)\b/.test(t);
+        if (!primitive && t.length > 0) {
+          const candidate = qualifyRef(t, owner.topicId ?? '');
+          if (structIds.has(candidate)) {
+            attr.isStructValue = true;
+            attr.structRef = candidate;
+            attr.structKind = 'single';
+            tryEmit(owner.id, candidate, attr.name);
+          }
+        }
+      }
+      if (attr.isReference) {
+        const m = attr.type?.match(/^(BAG|LIST)(?:\s+\{[^}]*\})?\s+OF\s+(\S+)$/);
+        if (m) {
+          const target = qualifyRef(m[2], owner.topicId ?? '');
+          if (structIds.has(target)) {
+            attr.isStructValue = true;
+            attr.structRef = target;
+            attr.structKind = m[1] === 'BAG' ? 'bag' : 'list';
+            tryEmit(owner.id, target, attr.name);
+          }
+        }
+      }
+    }
+    if (owner.data && Array.isArray(owner.data.attributes)) {
+      owner.data.attributes = owner.attributes;
+    }
+  }
+}
+
+export function decorateReferences(state: VisitState): void {
+  for (const ref of state.pendingReferences) {
+    state.relations.push({
+      id: `${ref.sourceClass}-${ref.attrName}-${ref.targetQualified}-ref`,
+      sourceId: ref.sourceClass,
+      targetId: ref.targetQualified,
+      type: 'REFERENCES',
+      role: ref.attrName,
+    });
+  }
+}
+
+export function decorateInheritedAttributes(state: VisitState): void {
+  const classById = new Map<string, IliClassNode>();
+  for (const node of state.nodes) {
+    if (node.type === 'CLASS' || node.type === 'STRUCTURE') {
+      classById.set(node.id, node as IliClassNode);
+    }
+  }
+
+  const superTypeOf = new Map<string, string>();
+  for (const rel of state.relations) {
+    if (rel.type === 'EXTENDS') superTypeOf.set(rel.sourceId, rel.targetId);
+  }
+
+  for (const [classId, classNode] of classById) {
+    const inherited: { className: string; attributes: IliAttribute[] }[] = [];
+    const visited = new Set<string>([classId]);
+    let current = superTypeOf.get(classId);
+    while (current && !visited.has(current)) {
+      visited.add(current);
+      const ancestor = classById.get(current);
+      if (!ancestor) break;
+      if (ancestor.attributes && ancestor.attributes.length > 0) {
+        inherited.push({ className: ancestor.name, attributes: ancestor.attributes });
+      }
+      current = superTypeOf.get(current);
+    }
+    classNode.inheritedAttributes = inherited;
+    classNode.data.inheritedAttributes = inherited;
+  }
+}
+
+export function decorateAssociations(state: VisitState): void {
+  state.parsedAssociations.forEach(assoc => {
+    const sourceNode = state.nodes.find(
+      n => n.type === 'CLASS' && n.id === assoc.sourceClass,
+    ) as IliClassNode | undefined;
+    const targetNode = state.nodes.find(
+      n => n.type === 'CLASS' && n.id === assoc.targetClass,
+    ) as IliClassNode | undefined;
+    // Self-Assoc nur einmal anhängen — sonst rendert die UI zwei Edges
+    // mit identischer Key und React Flow erzeugt Geister-Edges.
+    const isSelf = sourceNode && targetNode && sourceNode.id === targetNode.id;
+    if (sourceNode) {
+      sourceNode.associations = [...(sourceNode.associations ?? []), assoc];
+      sourceNode.data.associations = sourceNode.associations;
+    }
+    if (targetNode && !isSelf) {
+      targetNode.associations = [...(targetNode.associations ?? []), assoc];
+      targetNode.data.associations = targetNode.associations;
+    }
+
+    // Suchbarkeit: synthetischer ASSOCIATION-Node, damit `generateSearchOptions`
+    // den Assoc-Namen findet. Layout zentriert ihn via `layoutAssociationCenter`.
+    const topic = (sourceNode?.topicId as string | undefined) ?? (targetNode?.topicId as string | undefined) ?? '';
+    state.nodes.push({
+      id: assoc.id,
+      type: 'ASSOCIATION',
+      name: assoc.name,
+      position: { x: 0, y: 0 },
+      data: {
+        label: assoc.name,
+        association: assoc,
+        topic,
+        comment: assoc.comment,
+        isHighlighted: false,
+        isActive: false,
+      },
+    });
+  });
+}
+
+export function decorateDomainAttributes(state: VisitState): void {
+  state.nodes.forEach(node => {
+    if (node.type !== 'CLASS') return;
+    const classNode = node as IliClassNode;
+    classNode.attributes?.forEach(attr => {
+      if (attr.isInlineEnum || attr.isEnum) return;
+      const baseName = attr.type.includes('.') ? attr.type.split('.').pop()! : attr.type;
+      const domainValues = state.domainEnumsByName.get(baseName);
+      if (domainValues) {
+        attr.isDomainEnum = true;
+        attr.domainEnumName = baseName;
+        attr.enumValues = domainValues;
+      }
+    });
+  });
+}

--- a/src/features/ili-explorer/services/parser/grammar/advanced.ts
+++ b/src/features/ili-explorer/services/parser/grammar/advanced.ts
@@ -20,7 +20,7 @@ import {
   Surface, MultiSurface, Area, MultiArea,
   AnyClass, AnyStructure, Translation, Attribute, At,
   Extends, Extended, Abstract, Final,
-  Imports, Unqualified, Version, Where, Depends, On, No, Format,
+  Imports, Unqualified, Version, Where, Depends, On, No, Format, Based,
   Constraints, Basket, Restriction, Inherit, Base,
 } from '../tokens';
 
@@ -117,6 +117,7 @@ export function registerAdvancedRules(p: IliCstParserBuilder): void {
       { ALT: () => p.CONSUME(On) },
       { ALT: () => p.CONSUME(No) },
       { ALT: () => p.CONSUME(Format) },
+      { ALT: () => p.CONSUME(Based) },
       { ALT: () => p.CONSUME(Constraints) },
       { ALT: () => p.CONSUME(Basket) },
       { ALT: () => p.CONSUME(Restriction) },

--- a/src/features/ili-explorer/services/parser/grammar/attribute.ts
+++ b/src/features/ili-explorer/services/parser/grammar/attribute.ts
@@ -9,7 +9,7 @@ import {
   Bag, List, Of,
   Coord, MultiCoord, Polyline, MultiPolyline,
   Surface, MultiSurface, Area, MultiArea,
-  Star, Minus, DotDot,
+  Star, Minus, Plus, DotDot,
   Oid, Continuous, Subdivision,
   Circular, Clockwise, Counterclockwise, Refsys,
 } from '../tokens';
@@ -134,6 +134,9 @@ export function registerAttributeRules(p: IliCstParserBuilder): void {
   p.numericType = p.RULE('numericType', () => {
     p.CONSUME(Numeric);
     p.OPTION(() => p.SUBRULE(p.numericRange));
+    p.OPTION2(() => p.CONSUME(Circular));
+    p.OPTION3(() => p.SUBRULE(p.unitRef));
+    p.OPTION4(() => p.SUBRULE(p.refsysSuffix));
   });
 
   p.numericRange = p.RULE('numericRange', () => {
@@ -162,7 +165,10 @@ export function registerAttributeRules(p: IliCstParserBuilder): void {
   });
 
   p.signedNumber = p.RULE('signedNumber', () => {
-    p.OPTION(() => p.CONSUME(Minus));
+    p.OPTION(() => p.OR([
+      { ALT: () => p.CONSUME(Minus) },
+      { ALT: () => p.CONSUME(Plus) },
+    ]));
     p.CONSUME(NumberLiteral);
   });
 

--- a/src/features/ili-explorer/services/parser/grammar/class.ts
+++ b/src/features/ili-explorer/services/parser/grammar/class.ts
@@ -3,7 +3,7 @@ import {
   Class, Structure, Association, End, Equals, Semicolon, Comma, Colon,
   Identifier, LParen, RParen,
   Abstract, Final, Extends, Extended, External, Transient,
-  Attribute, Or, Restriction,
+  Attribute, Or, Restriction, Parameter,
   Oid, As, No,
   DashDash, CompositionArrow, AggregationArrow,
   Ordered,
@@ -47,6 +47,10 @@ export function registerClassRules(p: IliCstParserBuilder): void {
         { ALT: () => p.CONSUME2(Attribute) },
       ]);
     });
+    p.OPTION5(() => {
+      p.CONSUME(Parameter);
+      p.MANY2(() => p.SUBRULE2(p.attributeDef));
+    });
     p.CONSUME(End);
     p.CONSUME2(Identifier, { LABEL: 'classEndName' });
     p.CONSUME(Semicolon);
@@ -65,6 +69,10 @@ export function registerClassRules(p: IliCstParserBuilder): void {
         { ALT: () => p.SUBRULE(p.constraintClause) },
         { ALT: () => p.CONSUME2(Attribute) },
       ]);
+    });
+    p.OPTION4(() => {
+      p.CONSUME(Parameter);
+      p.MANY2(() => p.SUBRULE2(p.attributeDef));
     });
     p.CONSUME(End);
     p.CONSUME2(Identifier, { LABEL: 'structEndName' });

--- a/src/features/ili-explorer/services/parser/grammar/domain.ts
+++ b/src/features/ili-explorer/services/parser/grammar/domain.ts
@@ -4,7 +4,7 @@ import {
   Identifier, StringLiteral,
   LParen, RParen,
   Equals, Semicolon, Comma, Extends, DotDot,
-  Format, Ordered, Circular,
+  Format, Based, On, Ordered, Circular,
   Mandatory, Constraints, Colon,
   Abstract, Generic, Final,
 } from '../tokens';
@@ -33,6 +33,7 @@ export function registerDomainRules(p: IliCstParserBuilder): void {
       { ALT: () => p.SUBRULE6(p.textType) },
       { ALT: () => p.SUBRULE(p.oidDomainType) },
       { ALT: () => p.SUBRULE(p.formatType) },
+      { ALT: () => p.SUBRULE(p.formatRange) },
       { ALT: () => p.SUBRULE7(p.qualifiedName, { LABEL: 'aliasRef' }) },
     ]);
     p.OPTION3(() => p.SUBRULE(p.domainConstraintsClause));
@@ -72,13 +73,38 @@ export function registerDomainRules(p: IliCstParserBuilder): void {
 
   p.formatType = p.RULE('formatType', () => {
     p.CONSUME(Format);
-    p.OPTION(() => p.CONSUME(Identifier, { LABEL: 'formatBase' }));
+    p.OPTION3(() => {
+      p.CONSUME(Based);
+      p.CONSUME(On);
+    });
     p.SUBRULE(p.qualifiedName);
+    p.OPTION4(() => p.SUBRULE(p.formatSpec));
     p.OPTION2(() => {
       p.CONSUME(StringLiteral, { LABEL: 'minVal' });
       p.CONSUME(DotDot);
       p.CONSUME2(StringLiteral, { LABEL: 'maxVal' });
     });
+  });
+
+  p.formatSpec = p.RULE('formatSpec', () => {
+    p.CONSUME(LParen);
+    p.MANY(() => p.SUBRULE(p.formatSpecToken));
+    p.CONSUME(RParen);
+  });
+
+  p.formatSpecToken = p.RULE('formatSpecToken', () => {
+    p.OR([
+      { ALT: () => p.CONSUME(Identifier) },
+      { ALT: () => p.CONSUME(StringLiteral) },
+    ]);
+  });
+
+  // Refhb 3.8.4: Bereichseinschränkung auf einem FORMAT-typisierten Domain
+  // via String-Literal-Range, z.B. EXTENDS Angle_DMS = "-90:00:00.000" .. "90:00:00.000".
+  p.formatRange = p.RULE('formatRange', () => {
+    p.CONSUME(StringLiteral, { LABEL: 'formatMin' });
+    p.CONSUME(DotDot);
+    p.CONSUME2(StringLiteral, { LABEL: 'formatMax' });
   });
 
   p.allOfClause = p.RULE('allOfClause', () => {

--- a/src/features/ili-explorer/services/parser/grammar/topLevel.ts
+++ b/src/features/ili-explorer/services/parser/grammar/topLevel.ts
@@ -129,7 +129,7 @@ export function registerTopLevelRules(p: IliCstParserBuilder): void {
     p.SUBRULE(p.identifierLike);
     p.MANY(() => {
       p.CONSUME(Dot);
-      p.SUBRULE2(p.identifierLike);
+      p.SUBRULE(p.qualifiedSegment);
     });
   });
 
@@ -137,6 +137,19 @@ export function registerTopLevelRules(p: IliCstParserBuilder): void {
     p.OR([
       { ALT: () => p.CONSUME(Identifier) },
       { ALT: () => p.CONSUME(Interlis) },
+    ]);
+  });
+
+  // Segmente nach dem ersten Punkt in einem QualifiedName dürfen auch
+  // reservierte Wörter sein, die in der INTERLIS-Standard-Library als
+  // Klassen-/Domain-Namen vorkommen (Refhb 4.3): z.B. INTERLIS.REFSYSTEM,
+  // INTERLIS.COORDSYSTEM.
+  p.qualifiedSegment = p.RULE('qualifiedSegment', () => {
+    p.OR([
+      { ALT: () => p.CONSUME(Identifier) },
+      { ALT: () => p.CONSUME(Interlis) },
+      { ALT: () => p.CONSUME(Refsystem) },
+      { ALT: () => p.CONSUME(Coordsystem) },
     ]);
   });
 }

--- a/src/features/ili-explorer/services/parser/tokens.ts
+++ b/src/features/ili-explorer/services/parser/tokens.ts
@@ -112,6 +112,7 @@ export const Depends = kw('Depends', 'DEPENDS');
 export const On = kw('On', 'ON');
 export const No = kw('No', 'NO');
 export const Format = kw('Format', 'FORMAT');
+export const Based = kw('Based', 'BASED');
 export const In = kw('In', 'IN');
 export const Constraints = kw('Constraints', 'CONSTRAINTS');
 export const Parameter = kw('Parameter', 'PARAMETER');
@@ -185,7 +186,7 @@ export const allTokens: TokenType[] = [
   Interlis, Version, Model, Topic, Class, Structure, Association, Enumeration,
   Domain, Unit, Function, View, Graphic, Refsystem, Coordsystem, Imports,
   End, Extends, Extended, Abstract, Final, Mandatory, All, Of, Bag, List,
-  Reference, Base, Constraints, Constraint, Existence, Unique, Set, Where, Required,
+  Reference, Based, Base, Constraints, Constraint, Existence, Unique, Set, Where, Required,
   Numeric, Text, MText, Boolean, DateTime, Date,
   Coord, MultiCoord, Polyline, MultiPolyline, Surface, MultiSurface, Area, MultiArea,
   AnyClass, AnyStructure, Translation, Attribute, At, Ordered, Or, And, Not, Null, True, False,


### PR DESCRIPTION
Adds FORMAT BASED ON, optional PARAMETER blocks in class/structure bodies, reserved keywords (REFSYSTEM/COORDSYSTEM) as qualified-name tail segments, NUMERIC with suffixes without range, and `+` signed numbers. CoordSys.ili + Units.ili shipped as snapshot fixtures with provenance README. 138/138 tests green.