### PR TITLE
feat(ui): differentiate composition/aggregation from associations

### DIFF
--- a/src/common/theme/ThemeContext.tsx
+++ b/src/common/theme/ThemeContext.tsx
@@ -33,6 +33,7 @@ export interface ThemeColors {
   scrollbar: ScrollbarColors;
   shadow: string;
   relationship: string;
+  composition: string;
   reference: string;
   containment: string;
   selectedNodeBg: string;
@@ -79,6 +80,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
 
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
+    composition: '#6e8b60',     // Graugrün für Komposition/Aggregation
     reference: '#ff4081',       // Pink wie typeNode
     containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
     
@@ -139,6 +141,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
 
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
+    composition: '#6e8b60',     // Graugrün für Komposition/Aggregation
     reference: '#ff4081',       // Pink wie typeNode
     containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
 
@@ -199,6 +202,7 @@ const colorSchemes: Record<string, Record<string, any>> = {
 
     // Schema Explorer Node Farben
     relationship: '#4caf50',    // Grün für Beziehungen
+    composition: '#6e8b60',     // Graugrün für Komposition/Aggregation
     reference: '#ff4081',       // Pink wie typeNode
     containment: '#607d8b',     // Graublau für Strukturen / Komposition (CONTAINS)
 

--- a/src/features/ili-explorer/components/AssociationMarkerDefs.tsx
+++ b/src/features/ili-explorer/components/AssociationMarkerDefs.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTheme } from '../../../common/theme/ThemeContext';
+
+export const COMPOSITION_MARKER_ID = 'modvis-diamond-filled';
+export const AGGREGATION_MARKER_ID = 'modvis-diamond-open';
+
+const AssociationMarkerDefs: React.FC = () => {
+  const { colors } = useTheme();
+  const stroke = colors.composition;
+
+  return (
+    <svg
+      style={{ position: 'absolute', width: 0, height: 0, pointerEvents: 'none' }}
+      aria-hidden="true"
+    >
+      <defs>
+        <marker
+          id={COMPOSITION_MARKER_ID}
+          viewBox="0 0 12 12"
+          refX="11"
+          refY="6"
+          markerWidth="14"
+          markerHeight="14"
+          orient="auto-start-reverse"
+        >
+          <polygon points="0,6 6,2 12,6 6,10" fill={stroke} stroke={stroke} strokeWidth="1" />
+        </marker>
+        <marker
+          id={AGGREGATION_MARKER_ID}
+          viewBox="0 0 12 12"
+          refX="11"
+          refY="6"
+          markerWidth="14"
+          markerHeight="14"
+          orient="auto-start-reverse"
+        >
+          <polygon points="0,6 6,2 12,6 6,10" fill="white" stroke={stroke} strokeWidth="1.5" />
+        </marker>
+      </defs>
+    </svg>
+  );
+};
+
+export default AssociationMarkerDefs;

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -26,6 +26,7 @@ import { IliSideToolbar } from './toolbar/IliSideToolbar';
 import { IliSelectionOverlay } from './IliSelectionOverlay';
 import { IliDropOverlay } from './IliDropOverlay';
 import IliLegend from './legend/IliLegend';
+import AssociationMarkerDefs from './AssociationMarkerDefs';
 import {
   IliClassNode,
   IliModelNode,
@@ -703,6 +704,7 @@ const Flow: React.FC = () => {
         onMouseMove={isSelectingArea ? handleSelectionMove : undefined}
         onMouseUp={isSelectingArea ? handleSelectionEnd : undefined}
       >
+        <AssociationMarkerDefs />
         <Background />
         <Controls style={controlsStyle} />
         

--- a/src/features/ili-explorer/components/legend/IliLegend.tsx
+++ b/src/features/ili-explorer/components/legend/IliLegend.tsx
@@ -45,31 +45,24 @@ const IliLegend: React.FC<IliLegendProps> = ({
       isDisabled: !enumsVisible,
       onClick: () => onToggleEnums(!enumsVisible)
     },
-    { 
+    {
       label: 'ASSOCIATION',
       color: colors.relationship,
       isToggleable: true,
       isDisabled: !showAssociations,
       onClick: () => onToggleAssociations(!showAssociations)
     },
-    { 
-      label: 'ACTIVE', 
-      color: colors.selectedEntity,
-      isActive: true 
-    }
-  ];
-
-  const relationItems = [
-    { label: 'EXTENDS', color: colors.inheritance, style: 'solid' },
-    { label: 'DEPENDS ON', color: colors.relationship, style: 'dashed' },
-    { label: 'ASSOCIATES', color: colors.reference, style: 'dotted' },
-    { label: 'REFERENCES', color: colors.reference, style: 'dashed' },
-    { label: 'CONTAINS', color: colors.containment, style: 'solid' },
     {
-      label: 'ENUMERATION',
-      color: colors.typeReference,
-      style: 'dashed',
-      isDisabled: !enumsVisible
+      label: 'COMPOSITION',
+      color: colors.composition,
+      isToggleable: true,
+      isDisabled: !showAssociations,
+      onClick: () => onToggleAssociations(!showAssociations),
+    },
+    {
+      label: 'ACTIVE',
+      color: colors.selectedEntity,
+      isActive: true
     }
   ];
 
@@ -180,25 +173,57 @@ const IliLegend: React.FC<IliLegendProps> = ({
               <Typography variant="caption">EXTENDS</Typography>
             </Box>
 
-            <Box 
-              sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
                 gap: 1,
                 opacity: showAssociations ? 1 : 0.5,
                 cursor: 'pointer',
-                '&:hover': {
-                  opacity: 0.8
-                }
+                '&:hover': { opacity: 0.8 },
               }}
               onClick={() => onToggleAssociations(!showAssociations)}
             >
-              <Box sx={{ 
+              <Box sx={{
                 width: 20,
                 height: 0,
-                borderTop: `2px dashed ${colors.relationship}`
+                borderTop: `2px solid ${colors.relationship}`,
               }} />
               <Typography variant="caption">ASSOCIATES</Typography>
+            </Box>
+
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                opacity: showAssociations ? 1 : 0.5,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', width: 20, height: 10 }}>
+                <Box sx={{ flex: 1, height: 0, borderTop: `2px solid ${colors.composition}` }} />
+                <svg width="10" height="10" style={{ display: 'block' }}>
+                  <polygon points="5,1 9,5 5,9 1,5" fill={colors.composition} stroke={colors.composition} strokeWidth="1" />
+                </svg>
+              </Box>
+              <Typography variant="caption">COMPOSITION</Typography>
+            </Box>
+
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                opacity: showAssociations ? 1 : 0.5,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', width: 20, height: 10 }}>
+                <Box sx={{ flex: 1, height: 0, borderTop: `2px solid ${colors.composition}` }} />
+                <svg width="10" height="10" style={{ display: 'block' }}>
+                  <polygon points="5,1 9,5 5,9 1,5" fill="white" stroke={colors.composition} strokeWidth="1.5" />
+                </svg>
+              </Box>
+              <Typography variant="caption">AGGREGATION</Typography>
             </Box>
 
             <Box 

--- a/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
+++ b/src/features/ili-explorer/components/nodes/IliAssociationNode.tsx
@@ -41,6 +41,19 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
 
+  const kind = data.association.kind;
+  const stereotype =
+    kind === 'composition' ? '«COMPOSITION»'
+    : kind === 'aggregation' ? '«AGGREGATION»'
+    : '«ASSOCIATION»';
+  const stereotypeGlyph =
+    kind === 'composition' ? '◆'
+    : kind === 'aggregation' ? '◇'
+    : null;
+  const accentColor = (kind === 'composition' || kind === 'aggregation')
+    ? colors.composition
+    : colors.relationship;
+
   const handleExpandClick = useCallback((event: React.MouseEvent) => {
     event.stopPropagation();
     if (data.onExpandChange) {
@@ -89,11 +102,11 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
       sx={{ 
         width: width,
         position: 'relative',
-        border: data.isActive 
+        border: data.isActive
           ? `2px solid ${colors.selectedEntity}`
-          : data.isHighlighted 
-            ? `2px solid ${colors.selectedEntity}` 
-            : `2px solid ${colors.relationship}`,
+          : data.isHighlighted
+            ? `2px solid ${colors.selectedEntity}`
+            : `2px solid ${accentColor}`,
         borderRadius: 2,
         overflow: 'hidden',
         bgcolor: data.isActive ? colors.selectedNodeBg : colors.nodeContent,
@@ -181,8 +194,8 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
           bgcolor: data.isActive || data.isHighlighted
             ? colors.selectedEntity
             : data.isSource
-              ? alpha(colors.relationship, 0.8)
-              : alpha(colors.relationship, 0.5),
+              ? alpha(accentColor, 0.8)
+              : alpha(accentColor, 0.5),
           p: 1,
           textAlign: 'center',
           color: '#FFFFFF',
@@ -191,9 +204,10 @@ export const IliAssociationNode: React.FC<IliAssociationNodeProps> = memo(({ dat
           overflow: 'hidden'
         }}>
           <Typography variant="subtitle2" fontWeight="bold">
-            {data.association.kind === 'composition' ? '«COMPOSITION»'
-              : data.association.kind === 'aggregation' ? '«AGGREGATION»'
-              : '«ASSOCIATION»'}
+            {stereotypeGlyph && (
+              <Box component="span" sx={{ mr: 0.5, fontSize: '0.95em' }}>{stereotypeGlyph}</Box>
+            )}
+            {stereotype}
           </Typography>
           <Typography variant="subtitle1" fontWeight="bold">
             {data.association.name}

--- a/src/features/ili-explorer/services/__tests__/testHelpers.ts
+++ b/src/features/ili-explorer/services/__tests__/testHelpers.ts
@@ -27,6 +27,7 @@ export const mockColors: ThemeColors = {
   scrollbar: { track: '#000', thumb: '#000', thumbHover: '#000' },
   shadow: '#000',
   relationship: '#000',
+  composition: '#000',
   reference: '#000',
   containment: '#000',
   selectedNodeBg: '#000',

--- a/src/features/ili-explorer/services/layout/associationStrategy.ts
+++ b/src/features/ili-explorer/services/layout/associationStrategy.ts
@@ -1,7 +1,34 @@
-import { Edge, MarkerType } from '@xyflow/react';
+import { Edge, MarkerType, EdgeMarker } from '@xyflow/react';
 import type { ThemeColors } from '../../../../common/theme/ThemeContext';
 import type { IliAssociation, IliNode } from '../types/IliBaseTypes';
 import { LAYOUT_CONFIG } from './config';
+import {
+  COMPOSITION_MARKER_ID,
+  AGGREGATION_MARKER_ID,
+} from '../../components/AssociationMarkerDefs';
+
+function pickAssocMarker(
+  kind: 'composition' | 'aggregation' | 'plain',
+  color: string,
+): EdgeMarker | string {
+  if (kind === 'composition') return `url(#${COMPOSITION_MARKER_ID})`;
+  if (kind === 'aggregation') return `url(#${AGGREGATION_MARKER_ID})`;
+  return { type: MarkerType.Arrow, color, width: 20, height: 20 };
+}
+
+function pickAssocColor(
+  kind: 'composition' | 'aggregation' | 'plain',
+  colors: ThemeColors,
+): string {
+  if (kind === 'composition' || kind === 'aggregation') return colors.composition;
+  return colors.relationship;
+}
+
+const KIND_ORDER: Record<'plain' | 'aggregation' | 'composition', number> = {
+  plain: 0,
+  aggregation: 1,
+  composition: 2,
+};
 
 export function layoutAssociationCenter(
   entity: IliNode,
@@ -59,6 +86,11 @@ export function layoutAssociationCenter(
     });
   }
 
+  const kind = (association.kind ?? 'plain') as 'composition' | 'aggregation' | 'plain';
+  const stroke = pickAssocColor(kind, colors);
+  const isStrong = kind === 'composition' || kind === 'aggregation';
+  const centerEdgeStyle = { stroke, strokeWidth: 2 };
+
   if (sourceClass || unloadedSourceNode) {
     const sourceId = sourceClass?.id || unloadedSourceNode?.id || 'unknown';
     edges.push({
@@ -66,14 +98,11 @@ export function layoutAssociationCenter(
       source: sourceId,
       target: entity.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: true,
+      animated: !isStrong,
       sourceHandle: 'right-source',
       targetHandle: 'left-target',
-      style: {
-        stroke: colors.relationship,
-        strokeWidth: 2,
-        strokeDasharray: '5,5',
-      },
+      style: centerEdgeStyle,
+      markerEnd: pickAssocMarker(kind, stroke),
     });
   }
 
@@ -83,14 +112,11 @@ export function layoutAssociationCenter(
       source: entity.id,
       target: targetClass.id,
       type: useCurvedLines ? 'default' : 'step',
-      animated: true,
+      animated: !isStrong,
       sourceHandle: 'right-source',
       targetHandle: 'left-target',
-      style: {
-        stroke: colors.relationship,
-        strokeWidth: 2,
-        strokeDasharray: '5,5',
-      },
+      style: centerEdgeStyle,
+      markerEnd: pickAssocMarker(kind, stroke),
     });
   }
 
@@ -111,6 +137,10 @@ export function attachClassAssociations(
   if (!associations || associations.length === 0) return;
 
   const sortedAssociations = [...associations].sort((a, b) => {
+    const aKind = (a.kind ?? 'plain') as 'plain' | 'aggregation' | 'composition';
+    const bKind = (b.kind ?? 'plain') as 'plain' | 'aggregation' | 'composition';
+    const kindDelta = KIND_ORDER[aKind] - KIND_ORDER[bKind];
+    if (kindDelta !== 0) return kindDelta;
     const aIsSource = a.sourceClass === entity.id;
     const bIsSource = b.sourceClass === entity.id;
     return Number(aIsSource) - Number(bIsSource);
@@ -152,15 +182,8 @@ export function attachClassAssociations(
     enhancedNodes.push(associationNode);
 
     const kind = assoc.kind ?? 'plain';
+    const stroke = pickAssocColor(kind, colors);
     const isStrong = kind === 'composition' || kind === 'aggregation';
-    const edgeStyle: Record<string, string | number> = {
-      stroke: colors.relationship,
-      strokeWidth: isStrong ? 3 : 2,
-      ...(isStrong ? {} : { strokeDasharray: '5,5' }),
-    };
-    const markerType = kind === 'composition'
-      ? MarkerType.ArrowClosed
-      : MarkerType.Arrow;
     enumEdges.push({
       id: `${entity.id}-${associationNodeId}-assoc`,
       source: isSource ? entity.id : associationNodeId,
@@ -169,13 +192,8 @@ export function attachClassAssociations(
       animated: !isStrong,
       sourceHandle: isSource ? 'left-source' : 'right-source',
       targetHandle: isSource ? 'right-target' : 'left-target',
-      style: edgeStyle,
-      markerEnd: {
-        type: markerType,
-        color: colors.relationship,
-        width: 20,
-        height: 20,
-      },
+      style: { stroke, strokeWidth: 2 },
+      markerEnd: pickAssocMarker(kind, stroke),
     });
   });
 }


### PR DESCRIPTION
Adds a `composition` theme color (graugrün #6e8b60) and renders comp/agg associations with their own color, solid lines, filled/hollow diamond markers, and stable kind-sort (plain → agg → comp). Plain associations keep dashed-animated style. Legend gains COMPOSITION as an element entry plus pixel-aligned SVG diamonds in the relations section.