### PR TITLE
feat(ili-explorer): rich interactions for full schema view

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Mitwirken an modvis
 
 Danke fürs Interesse! modvis ist eine Open-Source-Visualisierung für INTERLIS-
-und EXPRESS-Schemas. Beiträge sind willkommen — Bug Reports, Modell-Samples,
+und EXPRESS-Modelle. Beiträge sind willkommen — Bug Reports, Modell-Samples,
 Grammar-Fixes, UI-Polish, Doku.
 
 Dieses Dokument beschreibt den Setup-Pfad, die Branch-Strategie und die

--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#613F82" />
 
-    <title>ILI Explorer · INTERLIS-Schemas visualisieren</title>
-    <meta name="description" content="ILI Explorer (modvis) zeigt INTERLIS-Modelle (.ili) als interaktiven Graph: Klassen, Vererbung, Aufzählungen, Assoziationen. Browserbasiert, ohne Upload, ohne Registrierung." />
+    <title>MODVIS · INTERLIS- Modelle visualisieren</title>
+    <meta name="description" content="MODVIS zeigt INTERLIS-Modelle (.ili) als interaktiven Graph: Klassen, Vererbung, Aufzählungen, Assoziationen. Browserbasiert, ohne Upload, ohne Registrierung." />
     <meta name="keywords" content="INTERLIS, ILI, ili2c, INTERLIS Modell, Modellvisualisierung, Schema Viewer, swisstopo, SIA405, AV93, MGDM, GIS Schweiz" />
     <link rel="canonical" href="https://www.iliexplorer.ch/" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="ILI Explorer" />
-    <meta property="og:title" content="ILI Explorer · INTERLIS-Schemas visualisieren" />
+    <meta property="og:site_name" content="MODVIS" />
+    <meta property="og:title" content="MODVIS · INTERLIS-Modelle visualisieren" />
     <meta property="og:description" content="INTERLIS-Modelle (.ili) als interaktiver Graph: Klassen, Vererbung, Aufzählungen, Assoziationen. Browserbasiert, ohne Upload." />
     <meta property="og:url" content="https://www.iliexplorer.ch/" />
     <meta property="og:image" content="https://www.iliexplorer.ch/og-image.png" />
@@ -54,9 +54,9 @@
   </head>
   <body>
     <noscript>
-      <h1>ILI Explorer · modvis</h1>
+      <h1>MODVIS · ILI Explorer</h1>
       <p>
-        Interaktiver Viewer für <strong>INTERLIS</strong>-Schemas.
+        Interaktiver Viewer für <strong>INTERLIS</strong>-Modelle.
         Lädt <code>.ili</code>-Dateien lokal im Browser und stellt Klassen, Vererbung,
         Aufzählungen und Assoziationen als Graph dar — ohne Upload, ohne Registrierung.
       </p>

--- a/src/features/ili-explorer/components/IliSchemaExplorer.tsx
+++ b/src/features/ili-explorer/components/IliSchemaExplorer.tsx
@@ -17,7 +17,9 @@ import {
   StepEdge,
   NodeMouseHandler,
 } from '@xyflow/react';
-import { Box, Alert, CircularProgress, Snackbar } from '@mui/material';
+import { Box, Alert, CircularProgress, Snackbar, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import OpenInNew from '@mui/icons-material/OpenInNew';
+import AccountTree from '@mui/icons-material/AccountTree';
 import { useTheme } from '../../../common/theme/ThemeContext';
 import { IliNode } from '../services/types/IliBaseTypes';
 
@@ -160,6 +162,7 @@ const Flow: React.FC = () => {
     registerNodeMove,
     registerNodeExpand,
     snapshotNodes,
+    isFullSchemaView,
     handleMaxSubTypesChange,
     fitViewRequest,
   } = useIliSchema(
@@ -220,8 +223,27 @@ const Flow: React.FC = () => {
 
   const [nodePositionsHistory, setNodePositionsHistory] = useState<Map<string, { x: number; y: number }>[]>([]);
 
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<
+    { x: number; y: number; nodeId: string; label: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!isFullSchemaView) {
+      setHighlightedId(null);
+      setContextMenu(null);
+    }
+  }, [isFullSchemaView]);
+
   const handleNodeClick = useCallback((event: React.MouseEvent, node: ReactFlowNode) => {
     if (node.type === 'topicLabelNode' || node.type === 'topicFrameNode') return;
+
+    if (isFullSchemaView) {
+      setContextMenu(null);
+      setHighlightedId(prev => (prev === node.id ? null : node.id));
+      return;
+    }
+
     if (node.id === activeNodeId) return;
 
     const iliNode: IliNode = {
@@ -236,7 +258,51 @@ const Flow: React.FC = () => {
     };
 
     baseHandleNodeClick(event, iliNode);
-  }, [activeNodeId, baseHandleNodeClick]);
+  }, [activeNodeId, baseHandleNodeClick, isFullSchemaView]);
+
+  const handleNodeContextMenu = useCallback((event: React.MouseEvent, node: ReactFlowNode) => {
+    if (node.type === 'topicLabelNode' || node.type === 'topicFrameNode') return;
+    event.preventDefault();
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      nodeId: node.id,
+      label: String(node.data?.label ?? node.id),
+    });
+  }, []);
+
+  const handlePaneClick = useCallback(() => {
+    setHighlightedId(null);
+    setContextMenu(null);
+  }, []);
+
+  const handleContextMenuJump = useCallback(() => {
+    if (!contextMenu) return;
+    const target = allNodes.find(n => n.id === contextMenu.nodeId);
+    setContextMenu(null);
+    setHighlightedId(null);
+    if (target) {
+      baseHandleNodeClick({} as React.MouseEvent, target as IliNode);
+    }
+  }, [contextMenu, allNodes, baseHandleNodeClick]);
+
+  const handleContextMenuToFullSchema = useCallback(() => {
+    if (!contextMenu) return;
+    const id = contextMenu.nodeId;
+    setContextMenu(null);
+    setHighlightedId(id);
+    showFullSchema();
+  }, [contextMenu, showFullSchema]);
+
+  const handleNodeDoubleClick = useCallback((event: React.MouseEvent, node: ReactFlowNode) => {
+    if (!isFullSchemaView) return;
+    if (node.type === 'topicLabelNode' || node.type === 'topicFrameNode') return;
+    const target = allNodes.find(n => n.id === node.id);
+    if (!target) return;
+    setContextMenu(null);
+    setHighlightedId(null);
+    baseHandleNodeClick(event, target as IliNode);
+  }, [isFullSchemaView, allNodes, baseHandleNodeClick]);
 
   const controlsStyle = useMemo(() => ({
     backgroundColor: colors.paper,
@@ -382,10 +448,70 @@ const Flow: React.FC = () => {
     return layoutHoverPreview(hovered, allNodes, allEdges, colors);
   }, [hoverPreviewEnabled, hoveredClassId, nodes, allNodes, allEdges, colors, activeSupertypeIds]);
 
-  const renderedNodes = useMemo(
-    () => [...nodesWithHandlers, ...hoverPreview.nodes],
-    [nodesWithHandlers, hoverPreview.nodes]
-  );
+  const keptIdsForHighlight = useMemo(() => {
+    if (!highlightedId || !isFullSchemaView) return null;
+    const ids = new Set<string>([highlightedId]);
+    const parentOf = new Map<string, string>();
+    const childrenOf = new Map<string, string[]>();
+    for (const e of edges) {
+      const rt = (e.data as { relationType?: string } | undefined)?.relationType;
+      if (rt !== 'EXTENDS') continue;
+      parentOf.set(e.source, e.target);
+      if (!childrenOf.has(e.target)) childrenOf.set(e.target, []);
+      childrenOf.get(e.target)!.push(e.source);
+    }
+    let cur = highlightedId;
+    while (parentOf.has(cur)) {
+      cur = parentOf.get(cur)!;
+      if (ids.has(cur)) break;
+      ids.add(cur);
+    }
+    const stack = [highlightedId];
+    while (stack.length) {
+      const id = stack.pop()!;
+      for (const c of childrenOf.get(id) ?? []) {
+        if (!ids.has(c)) {
+          ids.add(c);
+          stack.push(c);
+        }
+      }
+    }
+    const keptClassIds = new Set(ids);
+    const nodesById = new Map(nodes.map(n => [n.id, n]));
+    const isEnumOrAssoc = (id: string): boolean => {
+      const n = nodesById.get(id);
+      if (!n) return false;
+      return (
+        n.type === 'enumNode'
+        || n.type === 'domainEnumNode'
+        || n.type === 'ENUMERATION'
+        || n.type === 'associationNode'
+      );
+    };
+    for (const e of edges) {
+      if (keptClassIds.has(e.source) && isEnumOrAssoc(e.target)) ids.add(e.target);
+      if (keptClassIds.has(e.target) && isEnumOrAssoc(e.source)) ids.add(e.source);
+    }
+    return ids;
+  }, [highlightedId, isFullSchemaView, edges, nodes]);
+
+  const renderedNodes = useMemo(() => {
+    let base = nodesWithHandlers;
+    if (keptIdsForHighlight) {
+      base = base.map(n => {
+        const kept = keptIdsForHighlight.has(n.id);
+        const isCenter = n.id === highlightedId;
+        return {
+          ...n,
+          data: { ...n.data, isHighlighted: isCenter, isActive: isCenter },
+          style: kept
+            ? { ...n.style, opacity: 1, filter: undefined }
+            : { ...n.style, opacity: 0.22, filter: 'grayscale(0.85)' },
+        };
+      });
+    }
+    return [...base, ...hoverPreview.nodes];
+  }, [nodesWithHandlers, hoverPreview.nodes, keptIdsForHighlight, highlightedId]);
   // Pick the single edge from the hovered node to its closest neighbour in the
   // active-class hierarchy. For ancestors that's the direct child (one rank
   // closer to active); for subtypes / enums / assocs it's active itself.
@@ -431,8 +557,15 @@ const Flow: React.FC = () => {
           };
         })
       : withFade;
-    return [...tinted, ...hoverPreview.edges];
-  }, [edges, hoverPreview.edges, tintedEdgeId, colors.selectedEntity]);
+    const dimmed = keptIdsForHighlight
+      ? tinted.map(e => {
+          const visible = keptIdsForHighlight.has(e.source) && keptIdsForHighlight.has(e.target);
+          if (visible) return e;
+          return { ...e, style: { ...e.style, opacity: 0.1 } };
+        })
+      : tinted;
+    return [...dimmed, ...hoverPreview.edges];
+  }, [edges, hoverPreview.edges, tintedEdgeId, colors.selectedEntity, keptIdsForHighlight]);
 
  
   const debouncedHandleMaxSubTypesChange = useMemo(
@@ -457,6 +590,78 @@ const Flow: React.FC = () => {
       return next;
     });
   }, [handleNodeExpand, setNodes, snapshotNodes]);
+
+  const dragGroupRef = useRef<{
+    rootId: string;
+    rootOrigin: { x: number; y: number };
+    descendantOrigins: Map<string, { x: number; y: number }>;
+  } | null>(null);
+
+  const collectInheritanceDescendants = useCallback((rootId: string): Set<string> => {
+    const childrenByParent = new Map<string, string[]>();
+    for (const e of allEdges) {
+      const rt = (e.data as { relationType?: string } | undefined)?.relationType;
+      if (rt !== 'EXTENDS') continue;
+      if (!childrenByParent.has(e.target)) childrenByParent.set(e.target, []);
+      childrenByParent.get(e.target)!.push(e.source);
+    }
+    const out = new Set<string>();
+    const stack = [rootId];
+    while (stack.length) {
+      const id = stack.pop()!;
+      for (const child of childrenByParent.get(id) ?? []) {
+        if (!out.has(child)) {
+          out.add(child);
+          stack.push(child);
+        }
+      }
+    }
+    return out;
+  }, [allEdges]);
+
+  const handleNodeDragStart = useCallback((_event: React.MouseEvent, draggedNode: ReactFlowNode) => {
+    if (!isFullSchemaView) {
+      dragGroupRef.current = null;
+      return;
+    }
+    const descendantIds = collectInheritanceDescendants(draggedNode.id);
+    const descendantOrigins = new Map<string, { x: number; y: number }>();
+    for (const n of nodes) {
+      if (descendantIds.has(n.id)) {
+        descendantOrigins.set(n.id, { x: n.position.x, y: n.position.y });
+      }
+    }
+    dragGroupRef.current = {
+      rootId: draggedNode.id,
+      rootOrigin: { x: draggedNode.position.x, y: draggedNode.position.y },
+      descendantOrigins,
+    };
+  }, [isFullSchemaView, collectInheritanceDescendants, nodes]);
+
+  const handleNodeDrag = useCallback((_event: React.MouseEvent, draggedNode: ReactFlowNode) => {
+    const group = dragGroupRef.current;
+    if (!group || group.rootId !== draggedNode.id || group.descendantOrigins.size === 0) return;
+    const dx = draggedNode.position.x - group.rootOrigin.x;
+    const dy = draggedNode.position.y - group.rootOrigin.y;
+    setNodes(prev => prev.map(n => {
+      const origin = group.descendantOrigins.get(n.id);
+      if (!origin) return n;
+      return { ...n, position: { x: origin.x + dx, y: origin.y + dy } };
+    }));
+  }, [setNodes]);
+
+  const handleNodeDragStop = useCallback((_event: React.MouseEvent, draggedNode: ReactFlowNode) => {
+    const group = dragGroupRef.current;
+    registerNodeMove(draggedNode.id, draggedNode.position);
+    if (group && group.rootId === draggedNode.id) {
+      const dx = draggedNode.position.x - group.rootOrigin.x;
+      const dy = draggedNode.position.y - group.rootOrigin.y;
+      for (const [id, origin] of group.descendantOrigins) {
+        registerNodeMove(id, { x: origin.x + dx, y: origin.y + dy });
+      }
+    }
+    dragGroupRef.current = null;
+  }, [registerNodeMove]);
 
  
   const calculateBounds = (nodes: Node[]) => {
@@ -681,6 +886,9 @@ const Flow: React.FC = () => {
         edges={renderedEdges}
         onConnect={handleConnect}
         onNodeClick={handleNodeClick as unknown as NodeMouseHandler}
+        onNodeDoubleClick={handleNodeDoubleClick as unknown as NodeMouseHandler}
+        onNodeContextMenu={handleNodeContextMenu as unknown as NodeMouseHandler}
+        onPaneClick={handlePaneClick}
         onNodeMouseEnter={handleNodeMouseEnter as unknown as NodeMouseHandler}
         onNodeMouseLeave={handleNodeMouseLeave as unknown as NodeMouseHandler}
         nodeTypes={nodeTypes}
@@ -708,7 +916,9 @@ const Flow: React.FC = () => {
         elementsSelectable={true}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
-        onNodeDragStop={(_event, node) => registerNodeMove(node.id, node.position)}
+        onNodeDragStart={handleNodeDragStart}
+        onNodeDrag={handleNodeDrag}
+        onNodeDragStop={handleNodeDragStop}
         proOptions={{ hideAttribution: true }}
         onMouseDown={isSelectingArea ? handleSelectionStart : undefined}
         onMouseMove={isSelectingArea ? handleSelectionMove : undefined}
@@ -765,6 +975,7 @@ const Flow: React.FC = () => {
             onJumpToHistoryIndex={jumpToHistoryIndex}
             onShowOverview={showOverview}
             onShowFullSchema={showFullSchema}
+            isFullSchemaView={isFullSchemaView}
             useCurvedLines={useCurvedLines}
             exportAnchorEl={exportAnchorEl}
             onBack={handleBack}
@@ -795,6 +1006,37 @@ const Flow: React.FC = () => {
           }}
         />
       </ReactFlow>
+
+      <Menu
+        open={contextMenu !== null}
+        onClose={() => setContextMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          contextMenu ? { top: contextMenu.y, left: contextMenu.x } : undefined
+        }
+      >
+        {isFullSchemaView ? (
+          <MenuItem onClick={handleContextMenuJump}>
+            <ListItemIcon>
+              <OpenInNew fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary={`Zur Komponente ${contextMenu?.label ?? ''}`}
+              secondary="Detailansicht öffnen"
+            />
+          </MenuItem>
+        ) : (
+          <MenuItem onClick={handleContextMenuToFullSchema}>
+            <ListItemIcon>
+              <AccountTree fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary="Im Gesamtmodell zeigen"
+              secondary={`${contextMenu?.label ?? ''} hervorheben`}
+            />
+          </MenuItem>
+        )}
+      </Menu>
 
       {/* Toast-Benachrichtigung hinzufügen */}
       <Snackbar

--- a/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
+++ b/src/features/ili-explorer/components/toolbar/IliSideToolbar.tsx
@@ -75,6 +75,7 @@ function describeEntry(entry: NavigationState): { kind: string; label: string } 
 interface IliSideToolbarProps {
   currentFileName: string | null;
   activeNodeId: string | null;
+  isFullSchemaView?: boolean;
   historyIndex: number;
   canGoBack?: boolean;
   canGoForward?: boolean;
@@ -102,6 +103,7 @@ interface IliSideToolbarProps {
 export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
   currentFileName,
   activeNodeId,
+  isFullSchemaView,
   historyIndex,
   canGoBack,
   canGoForward,
@@ -128,6 +130,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
   const { colors } = useTheme();
   const noSchema = !currentFileName;
   const noNode = !currentFileName || !activeNodeId;
+  const noEditable = noNode && !isFullSchemaView;
 
   const [historyMenu, setHistoryMenu] = useState<{ anchor: HTMLElement; direction: HistoryDirection } | null>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -160,6 +163,12 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
     cancelLongPress();
     if (direction === 'back') onBack();
     else onForward();
+  };
+
+  const handleNavContextMenu = (direction: HistoryDirection) => (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    cancelLongPress();
+    setHistoryMenu({ anchor: event.currentTarget, direction });
   };
 
   const closeHistoryMenu = () => setHistoryMenu(null);
@@ -233,7 +242,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         </span>
       </Tooltip>
 
-      <Tooltip title="Zurück (lang drücken für Verlauf)" placement="right">
+      <Tooltip title="Zurück (lang drücken oder Rechtsklick für Verlauf)" placement="right">
         <span>
           <IconButton
             size="small"
@@ -242,6 +251,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
             onPointerUp={cancelLongPress}
             onPointerLeave={cancelLongPress}
             onPointerCancel={cancelLongPress}
+            onContextMenu={handleNavContextMenu('back')}
             disabled={canGoBack === undefined ? historyIndex <= 0 : !canGoBack}
             aria-label="Go back"
           >
@@ -250,7 +260,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         </span>
       </Tooltip>
 
-      <Tooltip title="Vorwärts (lang drücken für Verlauf)" placement="right">
+      <Tooltip title="Vorwärts (lang drücken oder Rechtsklick für Verlauf)" placement="right">
         <span>
           <IconButton
             size="small"
@@ -259,6 +269,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
             onPointerUp={cancelLongPress}
             onPointerLeave={cancelLongPress}
             onPointerCancel={cancelLongPress}
+            onContextMenu={handleNavContextMenu('forward')}
             disabled={!canGoForward}
             aria-label="Go forward"
           >
@@ -287,9 +298,11 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         {historyMenu?.direction === 'back' && backMenuItems.map(({ index, entry }) => {
           const desc = describeEntry(entry);
           const isOv = entry.isOverview;
+          const isFs = entry.isFullSchema;
           return (
-            <MenuItem key={`b-${index}`} onClick={jumpAndClose(index)} sx={isOv ? { gap: 1 } : undefined}>
+            <MenuItem key={`b-${index}`} onClick={jumpAndClose(index)} sx={isOv || isFs ? { gap: 1 } : undefined}>
               {isOv && <OverviewIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
+              {isFs && <AccountTree fontSize="small" sx={{ color: 'text.secondary' }} />}
               <ListItemText
                 primary={desc.label}
                 secondary={desc.kind}
@@ -302,9 +315,11 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
         {historyMenu?.direction === 'forward' && forwardMenuItems.map(({ index, entry }) => {
           const desc = describeEntry(entry);
           const isOv = entry.isOverview;
+          const isFs = entry.isFullSchema;
           return (
-            <MenuItem key={`f-${index}`} onClick={jumpAndClose(index)} sx={isOv ? { gap: 1 } : undefined}>
+            <MenuItem key={`f-${index}`} onClick={jumpAndClose(index)} sx={isOv || isFs ? { gap: 1 } : undefined}>
               {isOv && <OverviewIcon fontSize="small" sx={{ color: 'text.secondary' }} />}
+              {isFs && <AccountTree fontSize="small" sx={{ color: 'text.secondary' }} />}
               <ListItemText
                 primary={desc.label}
                 secondary={desc.kind}
@@ -343,7 +358,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
           <IconButton
             size="small"
             onClick={onResetLayout}
-            disabled={noNode}
+            disabled={noEditable}
             aria-label="Reset layout"
           >
             <RestartAlt fontSize="small" />
@@ -356,7 +371,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
           <IconButton
             size="small"
             onClick={onMagicLayout}
-            disabled={noNode}
+            disabled={noEditable}
             aria-label="Magic layout"
             sx={{
               color: theme => theme.palette.warning.main,
@@ -373,7 +388,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
           <IconButton
             size="small"
             onClick={onCollapseAll}
-            disabled={noNode}
+            disabled={noEditable}
             aria-label="Collapse all nodes"
           >
             <ExpandLess fontSize="small" />
@@ -386,7 +401,7 @@ export const IliSideToolbar: React.FC<IliSideToolbarProps> = ({
           <IconButton
             size="small"
             onClick={onExpandAll}
-            disabled={noNode}
+            disabled={noEditable}
             aria-label="Expand all nodes"
           >
             <ExpandMore fontSize="small" />

--- a/src/features/ili-explorer/hooks/useIliSchema.ts
+++ b/src/features/ili-explorer/hooks/useIliSchema.ts
@@ -63,6 +63,7 @@ interface UseIliSchemaReturn {
   canGoForward: boolean;
   showOverview: () => void;
   showFullSchema: () => void;
+  isFullSchemaView: boolean;
   registerNodeMove: (nodeId: string, position: { x: number; y: number }) => void;
   registerNodeExpand: (nodeId: string, expanded: boolean) => void;
   snapshotNodes: (nodes: IliNode[]) => void;
@@ -674,6 +675,31 @@ export const useIliSchema = (
   }, [activeNodeId, allNodes, displayNode, applyLayout, requestFitView]);
 
   const handleMagicLayout = useCallback(() => {
+    if (viewMode === 'fullSchema') {
+      sessionCacheRef.current.delete(FULL_SCHEMA_KEY);
+      const result = layoutFullSchemaCanvas(
+        allNodes as IliNode[],
+        allEdges,
+        colors,
+        useCurvedLines,
+        {
+          maxPerRow: maxSubTypesPerRow > 0 ? maxSubTypesPerRow : 4,
+          showEnums: fsShowEnums,
+          showAssociations: fsShowAssociations,
+          useMagicLayout: true,
+        },
+      );
+      const expandedNodes = result.nodes.map(n => ({
+        ...n,
+        data: { ...n.data, expanded: true, isExpanded: true },
+      }));
+      snapshotNodes(expandedNodes);
+      setNodes(expandedNodes);
+      setEdges(result.edges);
+      requestFitView();
+      return;
+    }
+
     if (!activeNodeId) return;
     const currentNode = allNodes.find(node => node.id === activeNodeId);
     if (!currentNode) return;
@@ -694,7 +720,7 @@ export const useIliSchema = (
     snapshotNodes(nodesWithExpandedStates);
     setNodes(nodesWithExpandedStates);
     setEdges(relatedNodes.edges);
-  }, [activeNodeId, allNodes, computeLayout, nodes, setNodes, setEdges, snapshotNodes]);
+  }, [viewMode, activeNodeId, allNodes, allEdges, colors, useCurvedLines, maxSubTypesPerRow, fsShowEnums, fsShowAssociations, computeLayout, nodes, setNodes, setEdges, snapshotNodes, requestFitView]);
 
   return {
     isLoading,
@@ -740,6 +766,7 @@ export const useIliSchema = (
     fitViewRequest,
     requestFitView,
     showFullSchema,
+    isFullSchemaView: viewMode === 'fullSchema',
     registerNodeMove,
     registerNodeExpand,
     snapshotNodes,

--- a/src/features/ili-explorer/services/layout/layoutFullSchemaCanvas.ts
+++ b/src/features/ili-explorer/services/layout/layoutFullSchemaCanvas.ts
@@ -26,7 +26,10 @@ export interface FullSchemaCanvasOptions {
   maxPerRow?: number;
   showEnums?: boolean;
   showAssociations?: boolean;
+  useMagicLayout?: boolean;
 }
+
+const MAGIC_VERTICAL_SCALE = 2.4;
 
 export interface FullSchemaCanvasResult {
   nodes: IliNode[];
@@ -48,6 +51,9 @@ export function layoutFullSchemaCanvas(
   const maxPerRow = Math.max(1, opts.maxPerRow ?? DEFAULT_MAX_PER_ROW);
   const showEnums = opts.showEnums ?? true;
   const showAssociations = opts.showAssociations ?? true;
+  const vScale = opts.useMagicLayout ? MAGIC_VERTICAL_SCALE : 1;
+  const effRowY = ROW_Y * vScale;
+  const effSecGapY = SECONDARY_GAP_Y * vScale;
 
   const synthesizedEnums = showEnums ? synthesizeMissingEnumNodes(allNodes) : [];
   const workingNodes: IliNode[] = [...allNodes, ...synthesizedEnums];
@@ -70,9 +76,10 @@ export function layoutFullSchemaCanvas(
     subTypeOf,
     byId,
     maxPerRow,
+    effRowY,
   );
-  const enumsGrid = layoutSecondaryGrid(enums);
-  const assocsGrid = layoutSecondaryGrid(assocs);
+  const enumsGrid = layoutSecondaryGrid(enums, effSecGapY);
+  const assocsGrid = layoutSecondaryGrid(assocs, effSecGapY);
 
   const hasAssocs = assocs.length > 0;
   const hasEnums = enums.length > 0;
@@ -267,6 +274,7 @@ function layoutTopicTrees(
   subTypeOf: Map<string, string>,
   byId: Map<string, IliNode>,
   maxPerRow: number,
+  rowY: number,
 ): { nodes: IliNode[]; width: number; depth: number } {
   if (members.length === 0) return { nodes: [], width: 0, depth: 0 };
 
@@ -302,7 +310,7 @@ function layoutTopicTrees(
   const TREE_GUTTER_SLOTS = 0.6;
   for (const rootId of roots) {
     const m = measureNode(rootId, childrenMap, maxPerRow, measureCache);
-    placeTreeNode(rootId, xSlots, 0, childrenMap, byId, maxPerRow, measureCache, out);
+    placeTreeNode(rootId, xSlots, 0, childrenMap, byId, maxPerRow, rowY, measureCache, out);
     xSlots += m.width + TREE_GUTTER_SLOTS;
     maxDepth = Math.max(maxDepth, m.height);
   }
@@ -319,7 +327,7 @@ function layoutTopicTrees(
   return { nodes: shifted, width: widthPx, depth: maxDepth };
 }
 
-function layoutSecondaryGrid(items: IliNode[]): { nodes: IliNode[]; width: number; height: number } {
+function layoutSecondaryGrid(items: IliNode[], gapY: number): { nodes: IliNode[]; width: number; height: number } {
   if (items.length === 0) return { nodes: [], width: 0, height: 0 };
   const sorted = [...items].sort((a, b) => labelOf(a).localeCompare(labelOf(b)));
   const cols = Math.min(SECONDARY_COLS, sorted.length);
@@ -332,12 +340,12 @@ function layoutSecondaryGrid(items: IliNode[]): { nodes: IliNode[]; width: numbe
       ...n,
       position: {
         x: col * (SECONDARY_NODE_W + SECONDARY_GAP_X),
-        y: row * (SECONDARY_NODE_H + SECONDARY_GAP_Y),
+        y: row * (SECONDARY_NODE_H + gapY),
       },
     });
   });
   const width = cols * SECONDARY_NODE_W + (cols - 1) * SECONDARY_GAP_X;
-  const height = rows * SECONDARY_NODE_H + (rows - 1) * SECONDARY_GAP_Y;
+  const height = rows * SECONDARY_NODE_H + (rows - 1) * gapY;
   return { nodes, width, height };
 }
 
@@ -392,6 +400,7 @@ function placeTreeNode(
   childrenMap: Map<string, string[]>,
   byId: Map<string, IliNode>,
   maxPerRow: number,
+  rowY: number,
   cache: Map<string, NodeMeasure>,
   out: IliNode[],
 ): void {
@@ -402,7 +411,7 @@ function placeTreeNode(
   if (node) {
     out.push({
       ...node,
-      position: { x: centerX - NODE_W / 2, y: yDepth * ROW_Y },
+      position: { x: centerX - NODE_W / 2, y: yDepth * rowY },
     });
   }
 
@@ -425,7 +434,7 @@ function placeTreeNode(
     let xCursor = xLeftSlots + (m.width - rowWidth) / 2;
     for (let i = start; i < end; i++) {
       const sub = measureNode(kids[i], childrenMap, maxPerRow, cache);
-      placeTreeNode(kids[i], xCursor, yCursorDepth, childrenMap, byId, maxPerRow, cache, out);
+      placeTreeNode(kids[i], xCursor, yCursorDepth, childrenMap, byId, maxPerRow, rowY, cache, out);
       xCursor += sub.width;
     }
     yCursorDepth += rowMaxHeight;


### PR DESCRIPTION
Click highlights a component plus its ancestors, descendants and connected enums/associations (dimming everything else); right-click shows a context menu with cross-view jumps, double-click jumps to focus view, dragging a class drags its EXTENDS-subtree along. Reset/magic/ expand-all/collapse-all now work in full schema; back/forward arrows also open the history on right-click; full-schema entries get an icon.
